### PR TITLE
(SIMP-250) Relax facter dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,6 @@
-## 2015-06-29 - First Release 0.1.0
+## 2015-07-07 - Relax dependencies 1.0.1
+- Fixed bug where the facter dep was too stringent for bundler to resolve in
+  certain Travis tests.
+
+## 2015-06-29 - First Release 1.0.0
 - Happy Birthday!

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 # Variables:
 #
-# SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
-# PUPPET_VERSION   | specifies the version of the puppet gem to load
+# SIMP_GEM_SERVERS   | a space/comma delimited list of rubygem servers
+# PUPPET_VERSION     | specifies the version of the puppet gem to load
+# FACTER_GEM_VERSION | specifies the version of the facter to load
 puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['~>3']
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
@@ -9,8 +10,10 @@ gem_sources.each { |gem_source| source gem_source }
 
 gemspec
 
+if puppetversion = ENV['PUPPET_VERSION']
+  gem 'puppet', puppetversion, :require => false
+end
+
 if facterversion = ENV['FACTER_GEM_VERSION']
   gem 'facter', facterversion, :require => false
-else
-  gem 'facter', :require => false
 end

--- a/lib/simp/rspec-puppet-facts.rb
+++ b/lib/simp/rspec-puppet-facts.rb
@@ -1,6 +1,6 @@
 module Simp; end
 module Simp::RspecPuppetFacts
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 
   # TODO: roll this into files
   def extra_os_facts

--- a/simp-rspec-puppet-facts.gemspec
+++ b/simp-rspec-puppet-facts.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'coveralls',          '~> 0'
   s.add_development_dependency 'mocha',              '~> 1'
   s.add_runtime_dependency     'json',               '~> 1'
-  s.add_runtime_dependency     'facter',             '~> 2'
+  s.add_runtime_dependency     'facter',             '>= 1.5.0', '< 3.0'
 
   s.add_development_dependency 'pry',                '~> 0'
   s.add_development_dependency 'pry-doc',            '~> 0'


### PR DESCRIPTION
Without this patch, bundler is unable to resolve facter during Travis
tests using certain values for PUPPET_VERSION (ex: '~> 3.2.0').

This patch relaxes that requirement in the gemspec and enables the
Gemfile to model specific version requirements with the environment
variables FACTER_GEM_VERSION and PUPPET_VERSION.

SIMP-20  #comment Relaxed facter dependency in simp-rspec-puppet-facts
SIMP-250 #close