### PR TITLE
(SIMP-251) Add spec tests

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,3 @@
---format
-d
+--format d
 --colour
 --backtrace

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache: bundler
 script:
   - bundle exec rake spec
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.5
@@ -20,7 +19,5 @@ env:
   - FACTER_GEM_VERSION="~> 2.0"
 matrix:
   fast_finish: true
-  allow_failures:
-    - rvm: 1.8.7
 notifications:
   email: false

--- a/lib/simp/rspec-puppet-facts.rb
+++ b/lib/simp/rspec-puppet-facts.rb
@@ -1,6 +1,6 @@
 module Simp; end
 module Simp::RspecPuppetFacts
-  VERSION = '1.0.1'
+  require File.expand_path('version', File.dirname(__FILE__))
 
   # TODO: roll this into files
   def extra_os_facts
@@ -39,12 +39,18 @@ module Simp::RspecPuppetFacts
   def on_supported_os( opts = {} )
     h = Simp::RspecPuppetFacts::Shim.on_supported_os( opts )
     h.each do | os, facts |
-       facts[:lsbmajdistrelease] = facts[:operatingsystemmajrelease]
-       extra_facts               = extra_os_facts.fetch( facts.fetch(:operatingsystem) ).fetch( facts.fetch(:operatingsystemmajrelease) ).fetch( facts.fetch(:architecture) )
+
+       # attempt to massage a major release version if missing (for facter 1.6)
+       rel = facts.fetch(:operatingsystemmajrelease,
+                         facts.fetch(:operatingsystemrelease).split('.').first)
+       facts[:lsbmajdistrelease] = rel
+       extra_facts               = extra_os_facts.fetch( facts.fetch( :operatingsystem )).fetch( rel ).fetch( facts.fetch(:architecture) )
        extra_opts_facts          = opts.fetch( :extra_facts, {} )
 
        facts.merge! extra_facts
        facts.merge! extra_opts_facts
+
+       facts
     end
 
     h

--- a/lib/simp/version.rb
+++ b/lib/simp/version.rb
@@ -1,0 +1,4 @@
+module Simp; end
+module Simp::RspecPuppetFacts
+  VERSION = '1.0.1'
+end

--- a/simp-rspec-puppet-facts.gemspec
+++ b/simp-rspec-puppet-facts.gemspec
@@ -1,6 +1,5 @@
 # -*- encoding: utf-8 -*-
-$LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
-require 'simp/rspec-puppet-facts'
+require  File.expand_path('lib/simp/version.rb', File.dirname(__FILE__))
 
 Gem::Specification.new do |s|
   s.name        = 'simp-rspec-puppet-facts'

--- a/spec/fixtures/metadata.json
+++ b/spec/fixtures/metadata.json
@@ -13,14 +13,14 @@
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "RedHat",
+      "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "6",
         "7"
       ]
     },
     {
-      "operatingsystem": "CentOS",
+      "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6",
         "7"

--- a/spec/simp_rspec_puppet_facts_spec.rb
+++ b/spec/simp_rspec_puppet_facts_spec.rb
@@ -7,15 +7,13 @@ describe 'Simp::RspecPuppetFacts' do
     context 'Without parameter' do
       subject { on_supported_os() }
 
-      context 'Without metadata.json' do
+      context 'Without a metadata.json file' do
         it { expect { subject }.to raise_error(StandardError, /Can't find metadata.json/) }
       end
 
-      context 'With a metadata.json' do
-
-        context 'With a broken metadata.json' do
-
-          context 'With missing operatingsystem_support section' do
+      context 'With a metadata.json file' do
+        context 'that is broken' do
+          context 'with missing operatingsystem_support section' do
             before :all do
               fixture = File.read('spec/fixtures/metadata.json_with_missing_operatingsystem_support')
               File.expects(:file?).with('metadata.json').returns true
@@ -26,7 +24,7 @@ describe 'Simp::RspecPuppetFacts' do
           end
         end
 
-        context 'With a valid metadata.json' do
+        context 'that is valid' do
           before :all do
             fixture = File.read('spec/fixtures/metadata.json')
             File.expects(:file?).with('metadata.json').returns true
@@ -48,13 +46,13 @@ describe 'Simp::RspecPuppetFacts' do
             ]
           end
           it 'should return SIMP-specific OS facts' do
-            expect(subject.map{ |os,data|  {os => 
-              data.select{ |x,v| x == :uid_min || x == :grub_version }}} 
+            expect(subject.map{ |os,data|  {os =>
+              data.select{ |x,v| x == :uid_min || x == :grub_version }}}
             ).to eq [
+              {"centos-6-x86_64"=>{:grub_version=>"0.97",       :uid_min=>"500"}},
+              {"centos-7-x86_64"=>{:grub_version=>"2.02~beta2", :uid_min=>"500"}},
               {"redhat-6-x86_64"=>{:grub_version=>"0.97",       :uid_min=>"500"}},
               {"redhat-7-x86_64"=>{:grub_version=>"2.02~beta2", :uid_min=>"500"}},
-              {"centos-6-x86_64"=>{:grub_version=>"0.97",       :uid_min=>"500"}},
-              {"centos-7-x86_64"=>{:grub_version=>"2.02~beta2", :uid_min=>"500"}}
             ]
           end
         end
@@ -87,14 +85,6 @@ describe 'Simp::RspecPuppetFacts' do
         expect(subject.keys.sort).to eq [
           'redhat-6-x86_64',
           'redhat-7-x86_64',
-        ]
-      end
-      it 'should return SIMP-specific OS facts' do
-        expect(subject.map{ |os,data|  {os => 
-          data.select{ |x,v| x == :uid_min || x == :grub_version }}} 
-        ).to eq [
-          {"redhat-6-x86_64"=>{:grub_version=>"0.97",       :uid_min=>"500"}},
-          {"redhat-7-x86_64"=>{:grub_version=>"2.02~beta2", :uid_min=>"500"}},
         ]
       end
     end


### PR DESCRIPTION
Before this patch, Travis CI failed rubybgems-simp-rspec-puppet-facts
becuse it does not include spec tests.  This commit includes a common
battery of spec tests, adapted from rspec-puppet-facts.

SIMP-20  #comment added spec tests to rubybgems-simp-rspec-puppet-facts
SIMP-251 #close