### PR TITLE
(SIMP-ENV) Add ENV var support

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
 --format d
 --colour
 --backtrace
+--fail-fast

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,8 @@ gem_sources.each { |gem_source| source gem_source }
 
 gemspec
 
+
+
 if puppetversion = ENV['PUPPET_VERSION']
   gem 'puppet', puppetversion, :require => false
 end

--- a/README.md
+++ b/README.md
@@ -10,3 +10,19 @@ This gem acts as a shim in front of the most excellent [mcanevet/rspec-puppet-fa
 
 ## Motivation
 The `on_supported_os` method provided by rspec-puppet-facts provides facts captured from actual systems (captured in a brilliantly elegant [Vagrantfile](https://github.com/mcanevet/rspec-puppet-facts/blob/master/facts/Vagrantfile)).  However, many SIMP tests require additional custom facts.
+
+## Environment Variables
+### `SIMP_FACTS_OS`
+Example: `SIMP_FACTS_OS=redhat-6-x86_64,redhat-7-x86_64`
+
+
+### `SIMP_FACTS_selinux`
+- `enabled` _(default)_
+- `permissive`
+- `disabled`
+- `no`
+Example: `SIMP_FACTS_selinux=permissive`
+
+
+### `SIMP_FACTS_lsb`
+- `no`

--- a/lib/simp/rspec-puppet-facts.rb
+++ b/lib/simp/rspec-puppet-facts.rb
@@ -30,31 +30,87 @@ module Simp::RspecPuppetFacts
          'x86_64' => {
             :grub_version              => '2.02~beta2',
             :uid_min                   => '500',
+
           },
          },
       },
     }
   end
 
+
+
   def on_supported_os( opts = {} )
     h = Simp::RspecPuppetFacts::Shim.on_supported_os( opts )
+
     h.each do | os, facts |
+      facts.merge! lsb_facts( facts )
+      facts.merge! selinux_facts
+      facts.merge! extra_facts(facts)
+      facts.merge! opts.fetch( :extra_facts, {} )
 
-       # attempt to massage a major release version if missing (for facter 1.6)
-       rel = facts.fetch(:operatingsystemmajrelease,
-                         facts.fetch(:operatingsystemrelease).split('.').first)
-       facts[:lsbmajdistrelease] = rel
-       extra_facts               = extra_os_facts.fetch( facts.fetch( :operatingsystem )).fetch( rel ).fetch( facts.fetch(:architecture) )
-       extra_opts_facts          = opts.fetch( :extra_facts, {} )
+      if ( ENV.key?('SIMP_FACTS_OS') &&
+           !ENV['SIMP_FACTS_OS'].nil? &&
+           ENV['SIMP_FACTS_OS'].strip != '' &&
+           ENV['SIMP_FACTS_OS'] !~ /all/i )
+        unless ENV['SIMP_FACTS_OS'].split(/[ ,]+/).include? os
+          h.delete(os)
+        end
+      end
 
-       facts.merge! extra_facts
-       facts.merge! extra_opts_facts
-
-       facts
     end
 
     h
   end
+
+
+
+  def extra_facts( facts )
+      _rel  = facts.fetch(:operatingsystemmajrelease).split('.').first
+      _os   = facts.fetch( :operatingsystem )
+      _arch = facts.fetch(:architecture)
+      _extra_facts  = extra_os_facts.fetch(_os).fetch(_rel).fetch(_arch)
+  end
+
+  def lsb_facts( facts )
+    lsb_facts = {}
+    # attempt to massage a major release version if missing (for facter 1.6)
+    unless ENV['SIMP_FACTS_lsb'] == 'no'
+      puts "==== mocking lsb facts [disable with SIMP_FACTS_lsb=no]" if ENV['VERBOSE']
+      rel = facts.fetch(:operatingsystemmajrelease,
+                        facts.fetch(:operatingsystemrelease).split('.').first)
+      lsb_facts[:lsbmajdistrelease] = rel
+    end
+    lsb_facts
+  end
+
+  def selinux_facts
+    sefacts = {}
+    unless ENV['SIMP_FACTS_selinux'] == 'no'
+      puts "==== mocking selinux facts [disable with SIMP_FACTS_selinux=no]" if ENV['VERBOSE']
+      puts "====   options: SIMP_FACTS_selinux=no|enforcing|permissive|disabled" if ENV['VERBOSE']
+      sefacts_enforcing = {
+        :selinux              => true,
+        :selinux_current_mode => :enforcing,
+        :selinux_state        => :enforcing,
+      }
+      sefacts_permissive = {
+        :selinux              => true,
+        :selinux_current_mode => :permissive,
+        :selinux_state        => :permssive,
+      }
+      sefacts_disabled = {
+        :selinux              => false,
+        :selinux_current_mode => :disabled,
+        :selinux_state        => :disabled,
+      }
+      sefacts = sefacts_enforcing
+      sefacts = sefacts_enforcing  if ENV['SIMP_FACTS_selinux'] =~ /enforcing/i
+      sefacts = sefacts_permissive if ENV['SIMP_FACTS_selinux'] =~ /permissive/i
+      sefacts = sefacts_disabled   if ENV['SIMP_FACTS_selinux'] =~ /disabled/i
+    end
+    sefacts
+  end
+
 
   class Shim
     require 'rspec-puppet-facts'

--- a/lib/simp/version.rb
+++ b/lib/simp/version.rb
@@ -1,4 +1,4 @@
 module Simp; end
 module Simp::RspecPuppetFacts
-  VERSION = '1.0.1'
+  VERSION = '1.1.0'
 end

--- a/simp-rspec-puppet-facts.gemspec
+++ b/simp-rspec-puppet-facts.gemspec
@@ -25,7 +25,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency     'facter',             '>= 1.5.0', '< 3.0'
 
   s.add_development_dependency 'pry',                '~> 0'
-  s.add_development_dependency 'pry-doc',            '~> 0'
+  #s.add_development_dependency 'pry-doc',            '~> 0'
+  s.add_development_dependency 'tins',               '< 1.7' # 1.7+ breaks ruby 1.9
 
   s.requirements << 'rspec-puppet-facts'
 end

--- a/spec/simp_rspec_puppet_facts_spec.rb
+++ b/spec/simp_rspec_puppet_facts_spec.rb
@@ -32,6 +32,7 @@ describe 'Simp::RspecPuppetFacts' do
           end
 
           it 'should return a hash' do
+            on_supported_os()
             expect( on_supported_os().class ).to eq Hash
           end
           it 'should have 4 elements' do
@@ -54,12 +55,13 @@ describe 'Simp::RspecPuppetFacts' do
               {"redhat-6-x86_64"=>{:grub_version=>"0.97",       :uid_min=>"500"}},
               {"redhat-7-x86_64"=>{:grub_version=>"2.02~beta2", :uid_min=>"500"}},
             ]
+
           end
         end
       end
     end
 
-    context 'When specifying supported_os' do
+    context 'When specifying supported_os=redhat-6-x86_64,redhat-7-x86_64' do
       subject {
         on_supported_os(
           {
@@ -74,6 +76,28 @@ describe 'Simp::RspecPuppetFacts' do
             ]
           }
         )
+      }
+      it 'should return a hash' do
+        expect(subject.class).to eq Hash
+      end
+      it 'should have 2 elements' do
+        expect(subject.size).to eq 2
+      end
+      it 'should return supported OS' do
+        expect(subject.keys.sort).to eq [
+          'redhat-6-x86_64',
+          'redhat-7-x86_64',
+        ]
+      end
+    end
+
+    context 'When specifying SIMP_FACTS_OS=redhat-6-x86_64,redhat-7-x86_64' do
+      subject {
+        x = ENV['SIMP_FACTS_OS']
+        ENV['SIMP_FACTS_OS']='redhat-6-x86_64,redhat-7-x86_64'
+        h = on_supported_os()
+        ENV['SIMP_FACTS_OS']=x
+        h
       }
       it 'should return a hash' do
         expect(subject.class).to eq Hash

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'coveralls'
 Coveralls.wear!
 
 require 'rspec'
-require 'mocha/api'
+#require 'mocha/api'
 require 'simp/rspec-puppet-facts'
 include Simp::RspecPuppetFacts
 


### PR DESCRIPTION
This commit adds support for environment variables that influence the
SIMP facts that are included.

SIMP-ENV #comment `SIMP_FACTS_lsb=no`
SIMP-ENV #comment `SIMP_FACTS_selinux=no|enforcing|disabled|permissive`
SIMP-ENV #comment `SIMP_FACTS_OS=centos-6-x86_64,centos-7-x86_64`
SIMP-ENV #comment Bumped gem version to `1.1.0`
SIMP-ENV #close