### PR TITLE
(SIMP-1124) Updated rspec-puppet-facts in gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2016-05-23 - Updated rspec-puppet-facts
+- Grabbed the latest rspec puppet facts which brings in facterdb
+  for Fedora 23 support.
+
 ## 2016-05-07 - Collect SIMP module facts from running systems
 - Adapted `Vagrantfile` from facterdb to collect facts from any modules left
   under `facts/modules`.

--- a/lib/simp/version.rb
+++ b/lib/simp/version.rb
@@ -1,4 +1,4 @@
 module Simp; end
 module Simp::RspecPuppetFacts
-  VERSION = '1.3.0'
+  VERSION = '1.4.0'
 end

--- a/simp-rspec-puppet-facts.gemspec
+++ b/simp-rspec-puppet-facts.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files       = Dir['Rakefile', '{bin,lib,facts,spec}/**/*', 'README*', 'LICENSE*'] & `git ls-files -z .`.split("\0")
   s.test_files  = Dir['Rakefile', '{spec,test,facts}/**/*'] & `git ls-files -z .`.split("\0")
 
-  s.add_runtime_dependency     'rspec-puppet-facts', '~> 0'
+  s.add_runtime_dependency     'rspec-puppet-facts', '~> 1'
   s.add_development_dependency 'rake',               '~> 10'
   s.add_development_dependency 'rspec',              '~> 3.2'
 


### PR DESCRIPTION
The latest update brings in facterdb with Fedora23 support.

SIMP-1124 #close
