### PR TITLE
Add ssh_host_keys custom fact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2018-10-25 - Add ssh_host_keys custom fact - 2.2.0
+- Added a 'ssh_host_keys' custom fact to support the new fact that ships with
+  the SIMP ssh module.
+
 ## 2018-03-08 - Add OracleLinux 6 and 7 factssets - 2.1.0
 - Added factsets for OracleLinux 6 and 7
 - Updated the fact collection Vagrantfile and scripts to handle non-GCE

--- a/facts/2.0/centos-6-x86_64.facts
+++ b/facts/2.0/centos-6-x86_64.facts
@@ -135,6 +135,10 @@
   "operatingsystemrelease": "6.9",
   "swapfree": "1.50 GB",
   "id": "root",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "defaultgateway": "10.0.2.2",
   "hostname": "foo",
   "ipaddress": "10.0.2.15",

--- a/facts/2.0/centos-7-x86_64.facts
+++ b/facts/2.0/centos-7-x86_64.facts
@@ -533,6 +533,11 @@
     }
   },
   "openldap_arch": "i386",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "openssh_version": "6.6.1",
   "puppet_vardir": "/var/lib/puppet",
   "puppet_environmentpath": "",

--- a/facts/2.0/oraclelinux-6-x86_64.facts
+++ b/facts/2.0/oraclelinux-6-x86_64.facts
@@ -566,6 +566,10 @@
     "sysv"
   ],
   "openldap_arch": "i386",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "openssh_version": "5.3",
   "root_home": "/root",
   "is_pe": false,

--- a/facts/2.0/oraclelinux-7-x86_64.facts
+++ b/facts/2.0/oraclelinux-7-x86_64.facts
@@ -579,6 +579,11 @@
     "sysv"
   ],
   "openldap_arch": "i386",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "openssh_version": "6.6.1",
   "root_home": "/root",
   "is_pe": false,

--- a/facts/2.0/redhat-6-x86_64.facts
+++ b/facts/2.0/redhat-6-x86_64.facts
@@ -81,6 +81,10 @@
   "kernelmajversion": "2.6",
   "sshfp_rsa": "SSHFP 1 1 0b92f7d2f350d96251f0a0c4499f4ac4b79916dc\nSSHFP 1 2 ab11db5c12cc4c5498c3b00b5aff87c89ce0dea9f03674d5392b345be8273074",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "puppetversion": "3.8.7",
   "tmp_mount_fstype_dev_shm": "tmpfs",
   "swapsize": "0.00 MB",

--- a/facts/2.0/redhat-7-x86_64.facts
+++ b/facts/2.0/redhat-7-x86_64.facts
@@ -539,6 +539,11 @@
   "tmp_mount_fstype_dev_shm": "tmpfs",
   "uid_min": "1000",
   "openldap_arch": "i386",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "openssh_version": "6.6.1",
   "package_provider": "yum",
   "is_pe": false,

--- a/facts/2.1/centos-6-x86_64.facts
+++ b/facts/2.1/centos-6-x86_64.facts
@@ -137,6 +137,10 @@
   "manufacturer": "innotek GmbH",
   "kernel": "Linux",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "ipaddress": "10.0.2.15",
   "rubysitedir": "/usr/lib/ruby/site_ruby/1.8",
   "mysql_server_id": 180684,

--- a/facts/2.1/centos-7-x86_64.facts
+++ b/facts/2.1/centos-7-x86_64.facts
@@ -555,6 +555,11 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "puppet_vardir": "/var/lib/puppet",
   "puppet_environmentpath": "",
   "root_home": "/root",

--- a/facts/2.1/oraclelinux-6-x86_64.facts
+++ b/facts/2.1/oraclelinux-6-x86_64.facts
@@ -579,6 +579,10 @@
   ],
   "openldap_arch": "i386",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "root_home": "/root",
   "is_pe": false,
   "service_provider": "redhat",

--- a/facts/2.1/oraclelinux-7-x86_64.facts
+++ b/facts/2.1/oraclelinux-7-x86_64.facts
@@ -598,6 +598,11 @@
   ],
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "root_home": "/root",
   "is_pe": false,
   "service_provider": "systemd",

--- a/facts/2.1/redhat-6-x86_64.facts
+++ b/facts/2.1/redhat-6-x86_64.facts
@@ -333,6 +333,10 @@
   },
   "selinux_config_policy": "targeted",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "fips_ciphers": [
     "ECDHE-RSA-AES256-GCM-SHA384",
     "ECDHE-ECDSA-AES256-GCM-SHA384",

--- a/facts/2.1/redhat-7-x86_64.facts
+++ b/facts/2.1/redhat-7-x86_64.facts
@@ -626,6 +626,11 @@
   "uid_min": "1000",
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "package_provider": "yum",
   "is_pe": false,
   "puppet_vardir": "/var/lib/puppet",

--- a/facts/2.2/centos-6-x86_64.facts
+++ b/facts/2.2/centos-6-x86_64.facts
@@ -556,6 +556,10 @@
   "is_virtual": "true",
   "runlevel": "3",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "architecture": "x86_64",
   "osfamily": "RedHat",
   "package_provider": "yum",

--- a/facts/2.2/centos-7-x86_64.facts
+++ b/facts/2.2/centos-7-x86_64.facts
@@ -578,6 +578,11 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "puppet_vardir": "/var/lib/puppet",
   "puppet_environmentpath": "",
   "root_home": "/root",

--- a/facts/2.2/oraclelinux-6-x86_64.facts
+++ b/facts/2.2/oraclelinux-6-x86_64.facts
@@ -612,6 +612,10 @@
   ],
   "openldap_arch": "i386",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "root_home": "/root",
   "is_pe": false,
   "service_provider": "redhat",

--- a/facts/2.2/oraclelinux-7-x86_64.facts
+++ b/facts/2.2/oraclelinux-7-x86_64.facts
@@ -631,6 +631,11 @@
   ],
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "root_home": "/root",
   "is_pe": false,
   "service_provider": "systemd",

--- a/facts/2.2/redhat-6-x86_64.facts
+++ b/facts/2.2/redhat-6-x86_64.facts
@@ -4,6 +4,10 @@
   "ipv6_enabled": false,
   "processor0": "Intel(R) Xeon(R) CPU @ 2.30GHz",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "rubyversion": "1.8.7",
   "swapsize_mb": "0.00",
   "init_systems": [

--- a/facts/2.2/redhat-7-x86_64.facts
+++ b/facts/2.2/redhat-7-x86_64.facts
@@ -649,6 +649,11 @@
   "uid_min": "1000",
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "package_provider": "yum",
   "is_pe": false,
   "puppet_vardir": "/var/lib/puppet",

--- a/facts/2.3/centos-6-x86_64.facts
+++ b/facts/2.3/centos-6-x86_64.facts
@@ -422,6 +422,10 @@
   "ipaddress_lo": "127.0.0.1",
   "kernelmajversion": "2.6",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "runlevel": "3",
   "netmask_eth0": "255.255.255.0",
   "uuid": "4D1C8D9A-6F13-45FD-AE95-D01D1E1DA675",

--- a/facts/2.3/centos-7-x86_64.facts
+++ b/facts/2.3/centos-7-x86_64.facts
@@ -579,6 +579,11 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "puppet_vardir": "/var/lib/puppet",
   "puppet_environmentpath": "",
   "root_home": "/root",

--- a/facts/2.3/oraclelinux-6-x86_64.facts
+++ b/facts/2.3/oraclelinux-6-x86_64.facts
@@ -613,6 +613,10 @@
   ],
   "openldap_arch": "i386",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "root_home": "/root",
   "is_pe": false,
   "service_provider": "redhat",

--- a/facts/2.3/oraclelinux-7-x86_64.facts
+++ b/facts/2.3/oraclelinux-7-x86_64.facts
@@ -632,6 +632,11 @@
   ],
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "root_home": "/root",
   "is_pe": false,
   "service_provider": "systemd",

--- a/facts/2.3/redhat-6-x86_64.facts
+++ b/facts/2.3/redhat-6-x86_64.facts
@@ -425,6 +425,10 @@
   "netmask_eth0": "255.255.255.0",
   "uniqueid": "8e0a0300",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "puppet_environmentpath": "",
   "defaultgateway": "10.0.2.2",
   "os": {

--- a/facts/2.3/redhat-7-x86_64.facts
+++ b/facts/2.3/redhat-7-x86_64.facts
@@ -650,6 +650,11 @@
   "uid_min": "1000",
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "package_provider": "yum",
   "is_pe": false,
   "puppet_vardir": "/var/lib/puppet",

--- a/facts/2.4/centos-6-x86_64.facts
+++ b/facts/2.4/centos-6-x86_64.facts
@@ -227,6 +227,10 @@
   "id": "root",
   "netmask_lo": "255.0.0.0",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "macaddress_eth0": "52:54:00:2A:86:4C",
   "uptime_days": 0,
   "haveged_startup_provider": "init",

--- a/facts/2.4/centos-7-x86_64.facts
+++ b/facts/2.4/centos-7-x86_64.facts
@@ -579,6 +579,11 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "puppet_vardir": "/var/lib/puppet",
   "puppet_environmentpath": "",
   "root_home": "/root",

--- a/facts/2.4/oraclelinux-6-x86_64.facts
+++ b/facts/2.4/oraclelinux-6-x86_64.facts
@@ -613,6 +613,10 @@
   ],
   "openldap_arch": "i386",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "root_home": "/root",
   "is_pe": false,
   "service_provider": "redhat",

--- a/facts/2.4/oraclelinux-7-x86_64.facts
+++ b/facts/2.4/oraclelinux-7-x86_64.facts
@@ -632,6 +632,11 @@
   ],
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "root_home": "/root",
   "is_pe": false,
   "service_provider": "systemd",

--- a/facts/2.4/redhat-6-x86_64.facts
+++ b/facts/2.4/redhat-6-x86_64.facts
@@ -625,6 +625,10 @@
   },
   "reboot_required": false,
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "blockdevices": "sda",
   "mtu_eth0": 1460,
   "operatingsystemmajrelease": "6",

--- a/facts/2.4/redhat-7-x86_64.facts
+++ b/facts/2.4/redhat-7-x86_64.facts
@@ -651,6 +651,11 @@
   "uid_min": "1000",
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "package_provider": "yum",
   "is_pe": false,
   "puppet_vardir": "/var/lib/puppet",

--- a/facts/2.5/centos-6-x86_64.facts
+++ b/facts/2.5/centos-6-x86_64.facts
@@ -585,5 +585,9 @@
   "memorysize": "490.16 MB",
   "radius_version": "unknown",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "hardwareisa": "x86_64"
 }

--- a/facts/2.5/centos-7-x86_64.facts
+++ b/facts/2.5/centos-7-x86_64.facts
@@ -579,6 +579,11 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "puppet_vardir": "/var/lib/puppet",
   "puppet_environmentpath": "",
   "root_home": "/root",

--- a/facts/2.5/oraclelinux-6-x86_64.facts
+++ b/facts/2.5/oraclelinux-6-x86_64.facts
@@ -613,6 +613,10 @@
   ],
   "openldap_arch": "i386",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "root_home": "/root",
   "is_pe": false,
   "service_provider": "redhat",

--- a/facts/2.5/oraclelinux-7-x86_64.facts
+++ b/facts/2.5/oraclelinux-7-x86_64.facts
@@ -632,6 +632,11 @@
   ],
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "root_home": "/root",
   "is_pe": false,
   "service_provider": "systemd",

--- a/facts/2.5/redhat-6-x86_64.facts
+++ b/facts/2.5/redhat-6-x86_64.facts
@@ -127,6 +127,10 @@
   "netmask_eth0": "255.255.255.0",
   "rubyversion": "1.8.7",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "netmask_lo": "255.0.0.0",
   "shmall": "4294967296",
   "netmask": "255.255.255.0",

--- a/facts/2.5/redhat-7-x86_64.facts
+++ b/facts/2.5/redhat-7-x86_64.facts
@@ -651,6 +651,11 @@
   "uid_min": "1000",
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "package_provider": "yum",
   "is_pe": false,
   "puppet_vardir": "/var/lib/puppet",

--- a/facts/3.0/centos-6-x86_64.facts
+++ b/facts/3.0/centos-6-x86_64.facts
@@ -321,6 +321,10 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "operatingsystem": "CentOS",
   "operatingsystemmajrelease": "6",
   "operatingsystemrelease": "6.9",

--- a/facts/3.0/centos-7-x86_64.facts
+++ b/facts/3.0/centos-7-x86_64.facts
@@ -325,6 +325,11 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "operatingsystem": "CentOS",
   "operatingsystemmajrelease": "7",
   "operatingsystemrelease": "7.3.1611",

--- a/facts/3.0/oraclelinux-6-x86_64.facts
+++ b/facts/3.0/oraclelinux-6-x86_64.facts
@@ -386,6 +386,10 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "operatingsystem": "OracleLinux",
   "operatingsystemmajrelease": "6",
   "operatingsystemrelease": "6.7",

--- a/facts/3.0/oraclelinux-7-x86_64.facts
+++ b/facts/3.0/oraclelinux-7-x86_64.facts
@@ -411,6 +411,11 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "operatingsystem": "OracleLinux",
   "operatingsystemmajrelease": "7",
   "operatingsystemrelease": "7.2",

--- a/facts/3.0/redhat-6-x86_64.facts
+++ b/facts/3.0/redhat-6-x86_64.facts
@@ -412,6 +412,10 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "operatingsystem": "RedHat",
   "operatingsystemmajrelease": "6",
   "operatingsystemrelease": "6.9",

--- a/facts/3.0/redhat-7-x86_64.facts
+++ b/facts/3.0/redhat-7-x86_64.facts
@@ -411,6 +411,11 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "operatingsystem": "RedHat",
   "operatingsystemmajrelease": "7",
   "operatingsystemrelease": "7.3",

--- a/facts/3.3/centos-6-x86_64.facts
+++ b/facts/3.3/centos-6-x86_64.facts
@@ -415,6 +415,10 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "operatingsystem": "CentOS",
   "operatingsystemmajrelease": "6",
   "operatingsystemrelease": "6.9",

--- a/facts/3.3/centos-7-x86_64.facts
+++ b/facts/3.3/centos-7-x86_64.facts
@@ -419,6 +419,11 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "operatingsystem": "CentOS",
   "operatingsystemmajrelease": "7",
   "operatingsystemrelease": "7.3.1611",

--- a/facts/3.3/oraclelinux-6-x86_64.facts
+++ b/facts/3.3/oraclelinux-6-x86_64.facts
@@ -416,6 +416,10 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "operatingsystem": "OracleLinux",
   "operatingsystemmajrelease": "6",
   "operatingsystemrelease": "6.7",

--- a/facts/3.3/oraclelinux-7-x86_64.facts
+++ b/facts/3.3/oraclelinux-7-x86_64.facts
@@ -441,6 +441,11 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "operatingsystem": "OracleLinux",
   "operatingsystemmajrelease": "7",
   "operatingsystemrelease": "7.2",

--- a/facts/3.3/redhat-6-x86_64.facts
+++ b/facts/3.3/redhat-6-x86_64.facts
@@ -435,6 +435,10 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "operatingsystem": "RedHat",
   "operatingsystemmajrelease": "6",
   "operatingsystemrelease": "6.9",

--- a/facts/3.3/redhat-7-x86_64.facts
+++ b/facts/3.3/redhat-7-x86_64.facts
@@ -434,6 +434,11 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "operatingsystem": "RedHat",
   "operatingsystemmajrelease": "7",
   "operatingsystemrelease": "7.3",

--- a/facts/3.4/centos-6-x86_64.facts
+++ b/facts/3.4/centos-6-x86_64.facts
@@ -416,6 +416,10 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "operatingsystem": "CentOS",
   "operatingsystemmajrelease": "6",
   "operatingsystemrelease": "6.9",

--- a/facts/3.4/centos-7-x86_64.facts
+++ b/facts/3.4/centos-7-x86_64.facts
@@ -420,6 +420,11 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "operatingsystem": "CentOS",
   "operatingsystemmajrelease": "7",
   "operatingsystemrelease": "7.3.1611",

--- a/facts/3.4/oraclelinux-6-x86_64.facts
+++ b/facts/3.4/oraclelinux-6-x86_64.facts
@@ -417,6 +417,10 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "operatingsystem": "OracleLinux",
   "operatingsystemmajrelease": "6",
   "operatingsystemrelease": "6.7",

--- a/facts/3.4/oraclelinux-7-x86_64.facts
+++ b/facts/3.4/oraclelinux-7-x86_64.facts
@@ -442,6 +442,11 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "operatingsystem": "OracleLinux",
   "operatingsystemmajrelease": "7",
   "operatingsystemrelease": "7.2",

--- a/facts/3.4/redhat-6-x86_64.facts
+++ b/facts/3.4/redhat-6-x86_64.facts
@@ -436,6 +436,10 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "operatingsystem": "RedHat",
   "operatingsystemmajrelease": "6",
   "operatingsystemrelease": "6.9",

--- a/facts/3.4/redhat-7-x86_64.facts
+++ b/facts/3.4/redhat-7-x86_64.facts
@@ -435,6 +435,11 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "operatingsystem": "RedHat",
   "operatingsystemmajrelease": "7",
   "operatingsystemrelease": "7.3",

--- a/facts/3.5/centos-6-x86_64.facts
+++ b/facts/3.5/centos-6-x86_64.facts
@@ -431,6 +431,10 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "operatingsystem": "CentOS",
   "operatingsystemmajrelease": "6",
   "operatingsystemrelease": "6.9",

--- a/facts/3.5/centos-7-x86_64.facts
+++ b/facts/3.5/centos-7-x86_64.facts
@@ -516,6 +516,11 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "operatingsystem": "CentOS",
   "operatingsystemmajrelease": "7",
   "operatingsystemrelease": "7.3.1611",

--- a/facts/3.5/oraclelinux-6-x86_64.facts
+++ b/facts/3.5/oraclelinux-6-x86_64.facts
@@ -431,6 +431,10 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "operatingsystem": "OracleLinux",
   "operatingsystemmajrelease": "6",
   "operatingsystemrelease": "6.7",

--- a/facts/3.5/oraclelinux-7-x86_64.facts
+++ b/facts/3.5/oraclelinux-7-x86_64.facts
@@ -514,6 +514,11 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "operatingsystem": "OracleLinux",
   "operatingsystemmajrelease": "7",
   "operatingsystemrelease": "7.2",

--- a/facts/3.5/redhat-6-x86_64.facts
+++ b/facts/3.5/redhat-6-x86_64.facts
@@ -451,6 +451,10 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "operatingsystem": "RedHat",
   "operatingsystemmajrelease": "6",
   "operatingsystemrelease": "6.9",

--- a/facts/3.5/redhat-7-x86_64.facts
+++ b/facts/3.5/redhat-7-x86_64.facts
@@ -511,6 +511,11 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "operatingsystem": "RedHat",
   "operatingsystemmajrelease": "7",
   "operatingsystemrelease": "7.3",

--- a/facts/3.6/centos-6-x86_64.facts
+++ b/facts/3.6/centos-6-x86_64.facts
@@ -431,6 +431,10 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "operatingsystem": "CentOS",
   "operatingsystemmajrelease": "6",
   "operatingsystemrelease": "6.9",

--- a/facts/3.6/centos-7-x86_64.facts
+++ b/facts/3.6/centos-7-x86_64.facts
@@ -516,6 +516,11 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "operatingsystem": "CentOS",
   "operatingsystemmajrelease": "7",
   "operatingsystemrelease": "7.3.1611",

--- a/facts/3.6/oraclelinux-6-x86_64.facts
+++ b/facts/3.6/oraclelinux-6-x86_64.facts
@@ -431,6 +431,10 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "operatingsystem": "OracleLinux",
   "operatingsystemmajrelease": "6",
   "operatingsystemrelease": "6.7",

--- a/facts/3.6/oraclelinux-7-x86_64.facts
+++ b/facts/3.6/oraclelinux-7-x86_64.facts
@@ -514,6 +514,11 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "operatingsystem": "OracleLinux",
   "operatingsystemmajrelease": "7",
   "operatingsystemrelease": "7.2",

--- a/facts/3.6/redhat-6-x86_64.facts
+++ b/facts/3.6/redhat-6-x86_64.facts
@@ -451,6 +451,10 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "operatingsystem": "RedHat",
   "operatingsystemmajrelease": "6",
   "operatingsystemrelease": "6.9",

--- a/facts/3.6/redhat-7-x86_64.facts
+++ b/facts/3.6/redhat-7-x86_64.facts
@@ -511,6 +511,11 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "operatingsystem": "RedHat",
   "operatingsystemmajrelease": "7",
   "operatingsystemrelease": "7.3",

--- a/facts/3.7/centos-6-x86_64.facts
+++ b/facts/3.7/centos-6-x86_64.facts
@@ -431,6 +431,10 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "operatingsystem": "CentOS",
   "operatingsystemmajrelease": "6",
   "operatingsystemrelease": "6.9",

--- a/facts/3.7/centos-7-x86_64.facts
+++ b/facts/3.7/centos-7-x86_64.facts
@@ -516,6 +516,11 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "operatingsystem": "CentOS",
   "operatingsystemmajrelease": "7",
   "operatingsystemrelease": "7.3.1611",

--- a/facts/3.7/oraclelinux-6-x86_64.facts
+++ b/facts/3.7/oraclelinux-6-x86_64.facts
@@ -431,6 +431,10 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "operatingsystem": "OracleLinux",
   "operatingsystemmajrelease": "6",
   "operatingsystemrelease": "6.7",

--- a/facts/3.7/oraclelinux-7-x86_64.facts
+++ b/facts/3.7/oraclelinux-7-x86_64.facts
@@ -514,6 +514,11 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "operatingsystem": "OracleLinux",
   "operatingsystemmajrelease": "7",
   "operatingsystemrelease": "7.2",

--- a/facts/3.7/redhat-6-x86_64.facts
+++ b/facts/3.7/redhat-6-x86_64.facts
@@ -451,6 +451,10 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "5.3",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_dsa_key"
+  ],
   "operatingsystem": "RedHat",
   "operatingsystemmajrelease": "6",
   "operatingsystemrelease": "6.9",

--- a/facts/3.7/redhat-7-x86_64.facts
+++ b/facts/3.7/redhat-7-x86_64.facts
@@ -511,6 +511,11 @@
   },
   "openldap_arch": "i386",
   "openssh_version": "6.6.1",
+  "ssh_host_keys": [
+    "/etc/ssh/ssh_host_rsa_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+    "/etc/ssh/ssh_host_ed25519_key"
+  ],
   "operatingsystem": "RedHat",
   "operatingsystemmajrelease": "7",
   "operatingsystemrelease": "7.3",

--- a/lib/simp/version.rb
+++ b/lib/simp/version.rb
@@ -1,4 +1,4 @@
 module Simp; end
 module Simp::RspecPuppetFacts
-  VERSION = '2.1.0'
+  VERSION = '2.2.0'
 end


### PR DESCRIPTION
This adds the ssh_host_keys custom fact from the pupmod-simp-ssh
module for SIMP-5491.

SIMP-5491 #refs