### PR TITLE
(SIMP-7502)  Exclude NAT interface from facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2020-01-13 - Exclude NAT interface from facts
+- Updated acceptance test to disable NAT interface
+- Updated collected facts for:
+  - RHEL 8
+  - RHEL 7
+  - CentOS 8
+  - OEL8
+
 ## 2019-12-10 - Add OEL8 facts
 - Added collected facts for OEL8
 

--- a/facts/2.5/centos-8-x86_64.facts
+++ b/facts/2.5/centos-8-x86_64.facts
@@ -18,10 +18,10 @@
   "boardmanufacturer": "Oracle Corporation",
   "boardproductname": "VirtualBox",
   "boardserialnumber": "0",
-  "boot_dir_uuid": "1722b205-731d-4199-8a6d-fc3de67ee0d3",
+  "boot_dir_uuid": "7510feea-51b7-4b93-a6e4-b67a1ffe5d13",
   "chassistype": "Other",
   "cmdline": {
-    "BOOT_IMAGE": "(hd0,msdos1)/vmlinuz-4.18.0-80.7.1.el8_0.x86_64",
+    "BOOT_IMAGE": "(hd0,msdos1)/vmlinuz-4.18.0-80.11.2.el8_0.x86_64",
     "root": "/dev/mapper/cl_centos8-root",
     "ro": "",
     "no_timer_check": "",
@@ -40,12 +40,11 @@
     "processor0": {
       "vendor_id": "GenuineIntel",
       "cpu_family": "6",
-      "model": "62",
-      "model_name": "Intel(R) Core(TM) i7-4930K CPU @ 3.40GHz",
-      "stepping": "4",
-      "microcode": "0x19",
-      "cpu_MHz": "3410.070",
-      "cache_size": "12288 KB",
+      "model": "158",
+      "model_name": "Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz",
+      "stepping": "9",
+      "cpu_MHz": "4199.952",
+      "cache_size": "8192 KB",
       "physical_id": "0",
       "siblings": "1",
       "core_id": "0",
@@ -54,7 +53,7 @@
       "initial_apicid": "0",
       "fpu": "yes",
       "fpu_exception": "yes",
-      "cpuid_level": "13",
+      "cpuid_level": "22",
       "wp": "yes",
       "flags": [
         "fpu",
@@ -79,7 +78,6 @@
         "fxsr",
         "sse",
         "sse2",
-        "ht",
         "syscall",
         "nx",
         "rdtscp",
@@ -100,6 +98,7 @@
         "sse4_1",
         "sse4_2",
         "x2apic",
+        "movbe",
         "popcnt",
         "aes",
         "xsave",
@@ -107,16 +106,23 @@
         "rdrand",
         "hypervisor",
         "lahf_lm",
+        "abm",
+        "3dnowprefetch",
+        "invpcid_single",
         "pti",
         "fsgsbase",
+        "avx2",
+        "invpcid",
+        "rdseed",
+        "clflushopt",
         "md_clear",
         "flush_l1d"
       ],
       "bugs": "cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds",
-      "bogomips": "6820.14",
+      "bogomips": "8399.90",
       "clflush_size": "64",
       "cache_alignment": "64",
-      "address_sizes": "46 bits physical, 48 bits virtual",
+      "address_sizes": "39 bits physical, 48 bits virtual",
       "power_management": "power management"
     }
   },
@@ -152,7 +158,7 @@
     "product": {
       "name": "VirtualBox",
       "serial_number": "0",
-      "uuid": "6bd251ef-8ac4-40e2-806c-de0735e49fcd"
+      "uuid": "bb066ed8-3250-45bc-b714-c6b16667553b"
     }
   },
   "domain": "example.com",
@@ -247,8 +253,8 @@
   "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
-      "revision": "133076",
-      "version": "6.0.12"
+      "revision": "133893",
+      "version": "5.2.34"
     }
   },
   "id": "root",
@@ -267,9 +273,7 @@
   "interfaces": "eth0,eth1,lo",
   "ip6tables_version": "1.8.2",
   "ipaddress": "10.0.2.15",
-  "ipaddress6_eth1": "fe80::a00:27ff:fe9b:e267",
   "ipaddress_eth0": "10.0.2.15",
-  "ipaddress_eth1": "10.255.16.207",
   "ipaddress_lo": "127.0.0.1",
   "iptables_version": "1.8.2",
   "ipv6_enabled": false,
@@ -277,12 +281,12 @@
   "is_virtual": true,
   "kernel": "Linux",
   "kernelmajversion": "4.18",
-  "kernelrelease": "4.18.0-80.7.1.el8_0.x86_64",
+  "kernelrelease": "4.18.0-80.11.2.el8_0.x86_64",
   "kernelversion": "4.18.0",
   "load_averages": {
-    "15m": 0.23,
-    "1m": 0.76,
-    "5m": 0.55
+    "15m": 0.19,
+    "1m": 0.27,
+    "5m": 0.43
   },
   "login_defs": {
     "mail_dir": "/var/spool/mail",
@@ -303,39 +307,39 @@
     "usergroups_enab": true,
     "encrypt_method": "SHA512"
   },
-  "macaddress": "08:00:27:de:cc:81",
-  "macaddress_eth0": "08:00:27:de:cc:81",
-  "macaddress_eth1": "08:00:27:9b:e2:67",
+  "macaddress": "08:00:27:ab:7f:6b",
+  "macaddress_eth0": "08:00:27:ab:7f:6b",
+  "macaddress_eth1": "08:00:27:e8:05:89",
   "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.06 GiB",
-      "available_bytes": 2215100416,
-      "capacity": "0.35%",
+      "available_bytes": 2215624704,
+      "capacity": "0.33%",
       "total": "2.07 GiB",
       "total_bytes": 2222977024,
-      "used": "7.51 MiB",
-      "used_bytes": 7876608
+      "used": "7.01 MiB",
+      "used_bytes": 7352320
     },
     "system": {
-      "available": "511.73 MiB",
-      "available_bytes": 536584192,
-      "capacity": "37.70%",
+      "available": "508.17 MiB",
+      "available_bytes": 532852736,
+      "capacity": "38.13%",
       "total": "821.41 MiB",
-      "total_bytes": 861310976,
-      "used": "309.68 MiB",
-      "used_bytes": 324726784
+      "total_bytes": 861306880,
+      "used": "313.24 MiB",
+      "used_bytes": 328454144
     }
   },
-  "memoryfree": "511.73 MiB",
-  "memoryfree_mb": 511.7265625,
+  "memoryfree": "508.17 MiB",
+  "memoryfree_mb": 508.16796875,
   "memorysize": "821.41 MiB",
-  "memorysize_mb": 821.41015625,
+  "memorysize_mb": 821.40625,
   "mountpoints": {
     "/": {
-      "available": "26.72 GiB",
-      "available_bytes": 28694257664,
-      "capacity": "7.57%",
+      "available": "26.80 GiB",
+      "available_bytes": 28772519936,
+      "capacity": "7.32%",
       "device": "/dev/mapper/cl_centos8-root",
       "filesystem": "xfs",
       "options": [
@@ -348,12 +352,12 @@
       ],
       "size": "28.91 GiB",
       "size_bytes": 31043657728,
-      "used": "2.19 GiB",
-      "used_bytes": 2349400064
+      "used": "2.12 GiB",
+      "used_bytes": 2271137792
     },
     "/boot": {
-      "available": "851.41 MiB",
-      "available_bytes": 892764160,
+      "available": "851.40 MiB",
+      "available_bytes": 892755968,
       "capacity": "12.76%",
       "device": "/dev/sda1",
       "filesystem": "ext4",
@@ -364,12 +368,12 @@
       ],
       "size": "975.90 MiB",
       "size_bytes": 1023303680,
-      "used": "124.49 MiB",
-      "used_bytes": 130539520
+      "used": "124.50 MiB",
+      "used_bytes": 130547712
     },
     "/dev": {
       "available": "396.46 MiB",
-      "available_bytes": 415723520,
+      "available_bytes": 415719424,
       "capacity": "0%",
       "device": "devtmpfs",
       "filesystem": "devtmpfs",
@@ -377,12 +381,12 @@
         "rw",
         "seclabel",
         "nosuid",
-        "size=405980k",
-        "nr_inodes=101495",
+        "size=405976k",
+        "nr_inodes=101494",
         "mode=755"
       ],
       "size": "396.46 MiB",
-      "size_bytes": 415723520,
+      "size_bytes": 415719424,
       "used": "0 bytes",
       "used_bytes": 0
     },
@@ -459,7 +463,7 @@
     },
     "/run": {
       "available": "400.05 MiB",
-      "available_bytes": 419487744,
+      "available_bytes": 419483648,
       "capacity": "2.59%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -473,7 +477,7 @@
       "size": "410.70 MiB",
       "size_bytes": 430653440,
       "used": "10.65 MiB",
-      "used_bytes": 11165696
+      "used_bytes": 11169792
     },
     "/run/user/0": {
       "available": "82.14 MiB",
@@ -519,14 +523,10 @@
   "mtu_eth1": 1500,
   "mtu_lo": 65536,
   "netmask": "255.255.0.0",
-  "netmask6_eth1": "ffff:ffff:ffff:ffff::",
   "netmask_eth0": "255.255.0.0",
-  "netmask_eth1": "255.255.0.0",
   "netmask_lo": "255.0.0.0",
   "network": "10.0.2.0",
-  "network6_eth1": "fe80::",
   "network_eth0": "10.0.2.0",
-  "network_eth1": "10.255.0.0",
   "network_lo": "127.0.0.0",
   "networking": {
     "dhcp": "10.0.2.2",
@@ -544,34 +544,14 @@
         ],
         "dhcp": "10.0.2.2",
         "ip": "10.0.2.15",
-        "mac": "08:00:27:de:cc:81",
+        "mac": "08:00:27:ab:7f:6b",
         "mtu": 1500,
         "netmask": "255.255.0.0",
         "network": "10.0.2.0"
       },
       "eth1": {
-        "bindings": [
-          {
-            "address": "10.255.16.207",
-            "netmask": "255.255.0.0",
-            "network": "10.255.0.0"
-          }
-        ],
-        "bindings6": [
-          {
-            "address": "fe80::a00:27ff:fe9b:e267",
-            "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::"
-          }
-        ],
-        "ip": "10.255.16.207",
-        "ip6": "fe80::a00:27ff:fe9b:e267",
-        "mac": "08:00:27:9b:e2:67",
-        "mtu": 1500,
-        "netmask": "255.255.0.0",
-        "netmask6": "ffff:ffff:ffff:ffff::",
-        "network": "10.255.0.0",
-        "network6": "fe80::"
+        "mac": "08:00:27:e8:05:89",
+        "mtu": 1500
       },
       "lo": {
         "bindings": [
@@ -588,7 +568,7 @@
       }
     },
     "ip": "10.0.2.15",
-    "mac": "08:00:27:de:cc:81",
+    "mac": "08:00:27:ab:7f:6b",
     "mtu": 1500,
     "netmask": "255.255.0.0",
     "network": "10.0.2.0",
@@ -626,39 +606,39 @@
       "mount": "/",
       "size": "28.93 GiB",
       "size_bytes": 31058821120,
-      "uuid": "8bfa39e2-63c7-4eee-b41c-d82899a9569f"
+      "uuid": "ccf5a194-d2b1-46c3-938e-8f7886f3bc76"
     },
     "/dev/mapper/cl_centos8-swap": {
       "filesystem": "swap",
       "size": "2.07 GiB",
       "size_bytes": 2222981120,
-      "uuid": "68bb46aa-a6da-4bfa-bec7-aea2c17efd5a"
+      "uuid": "9d040170-c2dd-4be9-802a-0c401021081f"
     },
     "/dev/sda1": {
       "filesystem": "ext4",
       "mount": "/boot",
-      "partuuid": "1463c12d-01",
+      "partuuid": "e25051ae-01",
       "size": "1.00 GiB",
       "size_bytes": 1073741824,
-      "uuid": "1722b205-731d-4199-8a6d-fc3de67ee0d3"
+      "uuid": "7510feea-51b7-4b93-a6e4-b67a1ffe5d13"
     },
     "/dev/sda2": {
       "filesystem": "LVM2_member",
-      "partuuid": "1463c12d-02",
+      "partuuid": "e25051ae-02",
       "size": "31.00 GiB",
       "size_bytes": 33284947968,
-      "uuid": "0wQaOD-kFk7-sMd4-1DJv-w7Tv-iRbD-evjWHy"
+      "uuid": "nDSbKr-dIFx-5YcD-aHwE-KHWr-7HtL-kEEQxH"
     }
   },
   "path": "PATH:/opt/puppetlabs/bin:/opt/puppetlabs/puppet/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin",
   "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-4930K CPU @ 3.40GHz",
+  "processor0": "Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz",
   "processorcount": 1,
   "processors": {
     "count": 1,
     "isa": "x86_64",
     "models": [
-      "Intel(R) Core(TM) i7-4930K CPU @ 3.40GHz"
+      "Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz"
     ],
     "physicalcount": 1
   },
@@ -905,7 +885,7 @@
   "puppet_vardir": "/opt/puppetlabs/puppet/cache",
   "puppetversion": "5.5.17",
   "reboot_required": false,
-  "root_dir_uuid": "8bfa39e2-63c7-4eee-b41c-d82899a9569f",
+  "root_dir_uuid": "ccf5a194-d2b1-46c3-938e-8f7886f3bc76",
   "root_home": "/root",
   "rsyslogd": {
     "version": "8.37.0",
@@ -961,11 +941,6 @@
         "uuid": "5fb06bd0-0bb0-7ffb-45f1-d6edd65f3e03",
         "type": "802-3-ethernet",
         "name": "System eth0"
-      },
-      "eth1": {
-        "uuid": "9c92fad9-6ecb-3e6c-eb4d-8a47c6f50c04",
-        "type": "802-3-ethernet",
-        "name": "System eth1"
       }
     }
   },
@@ -988,47 +963,47 @@
   "ssh": {
     "ecdsa": {
       "fingerprints": {
-        "sha1": "SSHFP 3 1 1040ad240cc5931eff3cd5cb2c60663bfe5643b4",
-        "sha256": "SSHFP 3 2 3cf369fb6693dfc6ae5cc13bcc373c20e0df4787a2f19d2e81a0fd1c7251756e"
+        "sha1": "SSHFP 3 1 6e9840252dac0dffa70947cc27b8f01b1e003ae8",
+        "sha256": "SSHFP 3 2 2eadf12392bbfa350002b8c2596f2abc9b2cd3b4deb1b5b09849dda549aee297"
       },
-      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBMaGPGbEtCFVx1Nni07m9nepUpdUHfJw7mr44lkiX47d+RdYYs1QEio2/vGZjviiAKQ/G0c5mCRlGcgxBwvQr6I=",
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBO+GVTZwWLTQrx/Zjq7ysoNEMzWW3q/BmV5++DCAdR/nFe7OhWqfDncAy7DGUe2SD6iYVnczu7Zz2CQmugTGJ8Q=",
       "type": "ecdsa-sha2-nistp256"
     },
     "ed25519": {
       "fingerprints": {
-        "sha1": "SSHFP 4 1 d38d215878bc16fb4f3e9aa19610b10704edd765",
-        "sha256": "SSHFP 4 2 83f7b3ce3f5cf5029ecf9041165687bc67668abb5c310f247c85dce29bb5bda7"
+        "sha1": "SSHFP 4 1 228816ccd113e513965371790db5f1f796016b1a",
+        "sha256": "SSHFP 4 2 6b4bac4bc82b66d471f46e7b0f2838834fa764c9d201ddae40fe221cb2acd9a2"
       },
-      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIHbfzuUwAa87Pi3VzGmGxalPlhC8iQjJVi0gFx9qKhZc",
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIFZZ4WLo699EhGXmGCAV9tKmvWAJWXlae579FwyPOBQC",
       "type": "ssh-ed25519"
     },
     "rsa": {
       "fingerprints": {
-        "sha1": "SSHFP 1 1 6bb170768c198993741588288a4b3e35467b6c9f",
-        "sha256": "SSHFP 1 2 77f67aa90e9dfd93a66655575340f5887fd95572b523da50a398da6f2cb8001a"
+        "sha1": "SSHFP 1 1 e4cd365a91e036eac7724a25648955f2d44512d3",
+        "sha256": "SSHFP 1 2 3d7200bd2d27f46f25e08988c0598c9cdd483a6b019458d5391d34959d398598"
       },
-      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCuX4CcksIAbrt9rEpVDX3a71iC62+Y9H0kAjzdhDikIbpMKAbPaNs9PiyHEqis9IWIKjemBVh9CpbblPr9sNaZF91e1rfGTxv7N3N8zAUImQLjxfvTjnvv56YFXgAHxooGQclMQVd7sM8AwjlgiUokMF5uMRMISCcwFYX/U6E71XRLLLPA2kNSQ5gGEStfwOMPehgl3r4r7h/I20A6ef7kjC+enA3ICDGnsT0PcYiGiaxreOvKwUShXyq7/i2n6jlyX0YIgcmq2Y4ezj6rtqw9K8D0JbiVydEvF/8m8vYazjLyUmS2iT5T9nm8OCUSjfRmFUt95LqTkxaZgYviLc+z",
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABAQC9bHJFJjRVMaG+QVAW9nkl/FVE0yVqN+OyL8QEGvsxNVL7/wHUzcHnJ1JE98+qtz7J/uBgV5V+ff5L9vwQbxLvMZjow+e+6Fxfp7B4RR7mW4TsknxUf7ltT6E7p3yNOJmMocYzmro0uLs1YAZRi8so5lrF0XEzhtZmxw+GNl9U4B0A954KpWpUCpj+gW6mMEYiPng+D9Glcmy8ns1ky/7sZIoWPCS2sK4K1qHixTVHAb6/YFvW523pzj24Dr4zYSJwBWN5/253IU1Oxq2TeThVbebQKw02EztpnRhZnsMbZx99v/+rIMjVWH3Ec4LHbv7vW7H9PaslgpIgnLbbkGrJ",
       "type": "ssh-rsa"
     }
   },
   "ssh_host_keys": [
     "/etc/ssh/ssh_host_rsa_key"
   ],
-  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBMaGPGbEtCFVx1Nni07m9nepUpdUHfJw7mr44lkiX47d+RdYYs1QEio2/vGZjviiAKQ/G0c5mCRlGcgxBwvQr6I=",
-  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIHbfzuUwAa87Pi3VzGmGxalPlhC8iQjJVi0gFx9qKhZc",
-  "sshfp_ecdsa": "SSHFP 3 1 1040ad240cc5931eff3cd5cb2c60663bfe5643b4\nSSHFP 3 2 3cf369fb6693dfc6ae5cc13bcc373c20e0df4787a2f19d2e81a0fd1c7251756e",
-  "sshfp_ed25519": "SSHFP 4 1 d38d215878bc16fb4f3e9aa19610b10704edd765\nSSHFP 4 2 83f7b3ce3f5cf5029ecf9041165687bc67668abb5c310f247c85dce29bb5bda7",
-  "sshfp_rsa": "SSHFP 1 1 6bb170768c198993741588288a4b3e35467b6c9f\nSSHFP 1 2 77f67aa90e9dfd93a66655575340f5887fd95572b523da50a398da6f2cb8001a",
-  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCuX4CcksIAbrt9rEpVDX3a71iC62+Y9H0kAjzdhDikIbpMKAbPaNs9PiyHEqis9IWIKjemBVh9CpbblPr9sNaZF91e1rfGTxv7N3N8zAUImQLjxfvTjnvv56YFXgAHxooGQclMQVd7sM8AwjlgiUokMF5uMRMISCcwFYX/U6E71XRLLLPA2kNSQ5gGEStfwOMPehgl3r4r7h/I20A6ef7kjC+enA3ICDGnsT0PcYiGiaxreOvKwUShXyq7/i2n6jlyX0YIgcmq2Y4ezj6rtqw9K8D0JbiVydEvF/8m8vYazjLyUmS2iT5T9nm8OCUSjfRmFUt95LqTkxaZgYviLc+z",
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBO+GVTZwWLTQrx/Zjq7ysoNEMzWW3q/BmV5++DCAdR/nFe7OhWqfDncAy7DGUe2SD6iYVnczu7Zz2CQmugTGJ8Q=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIFZZ4WLo699EhGXmGCAV9tKmvWAJWXlae579FwyPOBQC",
+  "sshfp_ecdsa": "SSHFP 3 1 6e9840252dac0dffa70947cc27b8f01b1e003ae8\nSSHFP 3 2 2eadf12392bbfa350002b8c2596f2abc9b2cd3b4deb1b5b09849dda549aee297",
+  "sshfp_ed25519": "SSHFP 4 1 228816ccd113e513965371790db5f1f796016b1a\nSSHFP 4 2 6b4bac4bc82b66d471f46e7b0f2838834fa764c9d201ddae40fe221cb2acd9a2",
+  "sshfp_rsa": "SSHFP 1 1 e4cd365a91e036eac7724a25648955f2d44512d3\nSSHFP 1 2 3d7200bd2d27f46f25e08988c0598c9cdd483a6b019458d5391d34959d398598",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQC9bHJFJjRVMaG+QVAW9nkl/FVE0yVqN+OyL8QEGvsxNVL7/wHUzcHnJ1JE98+qtz7J/uBgV5V+ff5L9vwQbxLvMZjow+e+6Fxfp7B4RR7mW4TsknxUf7ltT6E7p3yNOJmMocYzmro0uLs1YAZRi8so5lrF0XEzhtZmxw+GNl9U4B0A954KpWpUCpj+gW6mMEYiPng+D9Glcmy8ns1ky/7sZIoWPCS2sK4K1qHixTVHAb6/YFvW523pzj24Dr4zYSJwBWN5/253IU1Oxq2TeThVbebQKw02EztpnRhZnsMbZx99v/+rIMjVWH3Ec4LHbv7vW7H9PaslgpIgnLbbkGrJ",
   "sssd_version": "2.0.0",
   "swapfree": "2.06 GiB",
-  "swapfree_mb": 2112.484375,
+  "swapfree_mb": 2112.984375,
   "swapsize": "2.07 GiB",
   "swapsize_mb": 2119.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
-    "seconds": 225,
+    "seconds": 209,
     "uptime": "0:03 hours"
   },
   "systemd": true,
@@ -1044,8 +1019,8 @@
   "uptime": "0:03 hours",
   "uptime_days": 0,
   "uptime_hours": 0,
-  "uptime_seconds": 225,
-  "uuid": "6bd251ef-8ac4-40e2-806c-de0735e49fcd",
+  "uptime_seconds": 209,
+  "uuid": "bb066ed8-3250-45bc-b714-c6b16667553b",
   "virtual": "virtualbox",
   "clientcert": "foo.example.com",
   "clientversion": "5.5.17",

--- a/facts/2.5/oraclelinux-8-x86_64.facts
+++ b/facts/2.5/oraclelinux-8-x86_64.facts
@@ -40,12 +40,11 @@
     "processor0": {
       "vendor_id": "GenuineIntel",
       "cpu_family": "6",
-      "model": "62",
-      "model_name": "Intel(R) Core(TM) i7-4930K CPU @ 3.40GHz",
-      "stepping": "4",
-      "microcode": "0x19",
-      "cpu_MHz": "3318.722",
-      "cache_size": "12288 KB",
+      "model": "158",
+      "model_name": "Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz",
+      "stepping": "9",
+      "cpu_MHz": "4199.952",
+      "cache_size": "8192 KB",
       "physical_id": "0",
       "siblings": "1",
       "core_id": "0",
@@ -54,7 +53,7 @@
       "initial_apicid": "0",
       "fpu": "yes",
       "fpu_exception": "yes",
-      "cpuid_level": "13",
+      "cpuid_level": "22",
       "wp": "yes",
       "flags": [
         "fpu",
@@ -79,7 +78,6 @@
         "fxsr",
         "sse",
         "sse2",
-        "ht",
         "syscall",
         "nx",
         "rdtscp",
@@ -100,6 +98,7 @@
         "sse4_1",
         "sse4_2",
         "x2apic",
+        "movbe",
         "popcnt",
         "aes",
         "xsave",
@@ -107,16 +106,23 @@
         "rdrand",
         "hypervisor",
         "lahf_lm",
+        "abm",
+        "3dnowprefetch",
+        "invpcid_single",
         "pti",
         "fsgsbase",
+        "avx2",
+        "invpcid",
+        "rdseed",
+        "clflushopt",
         "md_clear",
         "flush_l1d"
       ],
       "bugs": "cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds swapgs",
-      "bogomips": "6637.44",
+      "bogomips": "8399.90",
       "clflush_size": "64",
       "cache_alignment": "64",
-      "address_sizes": "46 bits physical, 48 bits virtual",
+      "address_sizes": "39 bits physical, 48 bits virtual",
       "power_management": "power management"
     }
   },
@@ -124,7 +130,6 @@
   "defaultgatewayiface": "eth0",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
-    "eth1": "10.255.0.1",
     "system": "10.0.2.2"
   },
   "disks": {
@@ -153,7 +158,7 @@
     "product": {
       "name": "VirtualBox",
       "serial_number": "0",
-      "uuid": "59b60a33-37de-4cd3-a368-8e5c1668c544"
+      "uuid": "f7a999a9-fc48-4ac8-b7c3-024bd2e83bbf"
     }
   },
   "domain": "example.com",
@@ -248,8 +253,8 @@
   "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
-      "revision": "133895",
-      "version": "6.0.14"
+      "revision": "133893",
+      "version": "5.2.34"
     }
   },
   "id": "root",
@@ -268,9 +273,8 @@
   "interfaces": "eth0,eth1,lo",
   "ip6tables_version": "1.8.2",
   "ipaddress": "10.0.2.15",
-  "ipaddress6_eth1": "fe80::a00:27ff:fe28:30bc",
+  "ipaddress6_eth1": "fe80::2610:8086:ad92:af7c",
   "ipaddress_eth0": "10.0.2.15",
-  "ipaddress_eth1": "10.255.78.108",
   "ipaddress_lo": "127.0.0.1",
   "iptables_version": "1.8.2",
   "ipv6_enabled": false,
@@ -281,9 +285,9 @@
   "kernelrelease": "4.18.0-147.el8.x86_64",
   "kernelversion": "4.18.0",
   "load_averages": {
-    "15m": 0.16,
-    "1m": 0.39,
-    "5m": 0.25
+    "15m": 0.17,
+    "1m": 0.38,
+    "5m": 0.27
   },
   "login_defs": {
     "mail_dir": "/var/spool/mail",
@@ -306,37 +310,37 @@
   },
   "macaddress": "08:00:27:ef:09:96",
   "macaddress_eth0": "08:00:27:ef:09:96",
-  "macaddress_eth1": "08:00:27:28:30:bc",
+  "macaddress_eth1": "08:00:27:13:06:96",
   "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
-      "available": "2.06 GiB",
-      "available_bytes": 2207498240,
-      "capacity": "0.51%",
+      "available": "2.05 GiB",
+      "available_bytes": 2206461952,
+      "capacity": "0.56%",
       "total": "2.07 GiB",
       "total_bytes": 2218782720,
-      "used": "10.76 MiB",
-      "used_bytes": 11284480
+      "used": "11.75 MiB",
+      "used_bytes": 12320768
     },
     "system": {
-      "available": "524.52 MiB",
-      "available_bytes": 549998592,
-      "capacity": "36.14%",
+      "available": "531.62 MiB",
+      "available_bytes": 557445120,
+      "capacity": "35.28%",
       "total": "821.39 MiB",
       "total_bytes": 861290496,
-      "used": "296.87 MiB",
-      "used_bytes": 311291904
+      "used": "289.77 MiB",
+      "used_bytes": 303845376
     }
   },
-  "memoryfree": "524.52 MiB",
-  "memoryfree_mb": 524.51953125,
+  "memoryfree": "531.62 MiB",
+  "memoryfree_mb": 531.62109375,
   "memorysize": "821.39 MiB",
   "memorysize_mb": 821.390625,
   "mountpoints": {
     "/": {
-      "available": "26.63 GiB",
-      "available_bytes": 28594188288,
-      "capacity": "7.90%",
+      "available": "26.69 GiB",
+      "available_bytes": 28660862976,
+      "capacity": "7.69%",
       "device": "/dev/mapper/ol_oracle8-root",
       "filesystem": "xfs",
       "options": [
@@ -349,8 +353,8 @@
       ],
       "size": "28.92 GiB",
       "size_bytes": 31047847936,
-      "used": "2.29 GiB",
-      "used_bytes": 2453659648
+      "used": "2.22 GiB",
+      "used_bytes": 2386984960
     },
     "/boot": {
       "available": "844.16 MiB",
@@ -463,8 +467,8 @@
     },
     "/run": {
       "available": "400.04 MiB",
-      "available_bytes": 419471360,
-      "capacity": "2.59%",
+      "available_bytes": 419467264,
+      "capacity": "2.60%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
       "options": [
@@ -477,7 +481,7 @@
       "size": "410.70 MiB",
       "size_bytes": 430645248,
       "used": "10.66 MiB",
-      "used_bytes": 11173888
+      "used_bytes": 11177984
     },
     "/run/user/0": {
       "available": "82.14 MiB",
@@ -525,12 +529,10 @@
   "netmask": "255.255.0.0",
   "netmask6_eth1": "ffff:ffff:ffff:ffff::",
   "netmask_eth0": "255.255.0.0",
-  "netmask_eth1": "255.255.0.0",
   "netmask_lo": "255.0.0.0",
   "network": "10.0.2.0",
   "network6_eth1": "fe80::",
   "network_eth0": "10.0.2.0",
-  "network_eth1": "10.255.0.0",
   "network_lo": "127.0.0.0",
   "networking": {
     "dhcp": "10.0.2.2",
@@ -554,28 +556,17 @@
         "network": "10.0.2.0"
       },
       "eth1": {
-        "bindings": [
-          {
-            "address": "10.255.78.108",
-            "netmask": "255.255.0.0",
-            "network": "10.255.0.0"
-          }
-        ],
         "bindings6": [
           {
-            "address": "fe80::a00:27ff:fe28:30bc",
+            "address": "fe80::2610:8086:ad92:af7c",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::"
           }
         ],
-        "dhcp": "10.0.2.2",
-        "ip": "10.255.78.108",
-        "ip6": "fe80::a00:27ff:fe28:30bc",
-        "mac": "08:00:27:28:30:bc",
+        "ip6": "fe80::2610:8086:ad92:af7c",
+        "mac": "08:00:27:13:06:96",
         "mtu": 1500,
-        "netmask": "255.255.0.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
-        "network": "10.255.0.0",
         "network6": "fe80::"
       },
       "lo": {
@@ -657,13 +648,13 @@
   },
   "path": "PATH:/opt/puppetlabs/bin:/opt/puppetlabs/puppet/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin",
   "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-4930K CPU @ 3.40GHz",
+  "processor0": "Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz",
   "processorcount": 1,
   "processors": {
     "count": 1,
     "isa": "x86_64",
     "models": [
-      "Intel(R) Core(TM) i7-4930K CPU @ 3.40GHz"
+      "Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz"
     ],
     "physicalcount": 1
   },
@@ -962,20 +953,15 @@
     },
     "enabled": true,
     "connection": {
+      "eth1": {
+        "uuid": "cdcf09f5-2ea0-301f-9201-1fe61c528c85",
+        "type": "802-3-ethernet",
+        "name": "Wired connection 1"
+      },
       "eth0": {
         "uuid": "5fb06bd0-0bb0-7ffb-45f1-d6edd65f3e03",
         "type": "802-3-ethernet",
         "name": "System eth0"
-      },
-      "eth1": {
-        "uuid": "9c92fad9-6ecb-3e6c-eb4d-8a47c6f50c04",
-        "type": "802-3-ethernet",
-        "name": "System eth1"
-      },
-      "": {
-        "uuid": "9e2b3cb4-df5a-32a7-a998-13aabe232a55",
-        "type": "802-3-ethernet",
-        "name": "Wired connection 1"
       }
     }
   },
@@ -998,26 +984,26 @@
   "ssh": {
     "ecdsa": {
       "fingerprints": {
-        "sha1": "SSHFP 3 1 fac879cfa8b1a1a67ba3bf7177ca078bd5d2496a",
-        "sha256": "SSHFP 3 2 0fe1f1c3cb0b0dd7ab701169d0f941088620b140f8d3a417a6cba1f10a9894c1"
+        "sha1": "SSHFP 3 1 88ba8e0a7fb7b5fdb7043eb822b92b871c4fa8ca",
+        "sha256": "SSHFP 3 2 2ac0834b7f55799f0973db1e2d32f57a25adafb3cb084f022c3cdeb072411fad"
       },
-      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNQLNsS+KS9zd/VmSL6PpD70wStoGYdqxBwwWEStjYlhVRd5XTb7+7OLJQ1nbpXpn6X85D4QgFQFADRLweBYUkw=",
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJAWvh3bh4hLuxVpahqPQyRDLE466/LlbLGBLu7KupUMa1A31StB0HlQh/lqsknbuDlsDaliWabFQSiKnbjmdHE=",
       "type": "ecdsa-sha2-nistp256"
     },
     "ed25519": {
       "fingerprints": {
-        "sha1": "SSHFP 4 1 840cf97be1785fdc70eebcc322ff65318c4489d7",
-        "sha256": "SSHFP 4 2 d8581523b8ea27ed5e5ff95e750c49aeeaf5a32875f9e1dbf743ae48b2981ef3"
+        "sha1": "SSHFP 4 1 063f4a80b82a17743a31a420ee3a6d819df964ac",
+        "sha256": "SSHFP 4 2 73624d596af1003703472dfd9449f281bcde6e9b87338aed409ac7c39f8c93b0"
       },
-      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIEt3pqT5CoxbaVyRgzXlTZt3otRSrpBYTZf0LGOqevTj",
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIJErhbn3XHmCnJx202ulP2SysQWW87qaivrj0SR1j3Xb",
       "type": "ssh-ed25519"
     },
     "rsa": {
       "fingerprints": {
-        "sha1": "SSHFP 1 1 3a0def545bd2e7c73058897010f459dc54b1d4dc",
-        "sha256": "SSHFP 1 2 7005d0f157b25d01ac04fd105210d877b6ba5b020a685d63de928c4ee621c55a"
+        "sha1": "SSHFP 1 1 0907f141846b55eb6ce39df61b7db7c0dfbd4ec1",
+        "sha256": "SSHFP 1 2 9429fbc834957a06456b3e2043068db642ace1e4f460f71c1b06b6f9cb5ab1af"
       },
-      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDkf0A/ZGRcI8cF4NLXJ1JjbzlvOcyo+hKy44/+kFdohyG9Es9wqvdFpzSnnoDYo7ADB+0CIVvlsmcNVvfbY5MkUujF7vWGHgVSpqQ2i+6W/kN+zM/FzdXkGdxIdfQ/JrEzn08kf/uHJUYPFuzqZdA4od1wgCIedTUV5wG73VoKtBcJ0fVYriy4c94pvNZWpjRk2GFBuGyNiLFKT6nF3yAPAAxl+GJoF3Dt3EFH0geJYcVrpFaeo0Rr2otU/3HFg7lOCopxsNkoeghC4WKXUJcWaQ187C5+kgaSkc71ulfyh757tpokHFjqO1D1R1cQIAetF3WreMnAakhtDYMj7AJ7Q/BcK/cFx+guNEZGtgLTYOtb8BlR9IZmU9ByVwgEQGmTHbwUWV8dAAK+ORnLDVUpjU0d/w2HyCcp8BG6QaCUWv9E9XhZt2i+JowYsFnd4OhEfU4P6vbHWsE8SywGy8Jpb6bTb0HTcrzdF0yolE2+16EPgEqbBEhHLDjEY/81kzc=",
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC/Ncf+3JlYrxiC67TS/6jBguUqSpZJ0kEG+zNVtN93iujw7GJ3o08J8FOJXQxhjp/+2Y6JVbSGEVL+oVQie9khoIPiCxie2mnafLyAB5KpP0zbDnS/0brPXqNqkpl7ZighutWAtfrXiE3aW8HDJvUlWWaBTY7rXFsKICP2FBTzjRApWziB8RSRlUs7goTy0SmKzvYJSf8wxarLEGkiiWvBz/6ealPaa+MfkRVZ0UPIsqCyyxkAmlwuS8W8rlFdO/FDHtqPbNzq63TQPFo3B7P3FhhVBjXeRRxBsybzj8tHnL9P4iWTLr1hzSCI+zbjoXe0wT87rKpG+ou+KV1jh4LzmXvjosxPZna5nhXd7jzj1gSOXfxVjb2k87pbvxJ2hH7LSpwJv/dM0JzDTy45kHMiaHOhRvY+mqAFaHO2Lbry1lXtu5eRnWbStiy2Uie2YYXy+YWOUD6P5ZBG7nrze8zGRGtxtXRzyHfuADoDnjUPsEhtzOHFwwPi0ZxrSBe3eTk=",
       "type": "ssh-rsa"
     }
   },
@@ -1026,21 +1012,21 @@
     "/etc/ssh/ssh_host_ecdsa_key",
     "/etc/ssh/ssh_host_ed25519_key"
   ],
-  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNQLNsS+KS9zd/VmSL6PpD70wStoGYdqxBwwWEStjYlhVRd5XTb7+7OLJQ1nbpXpn6X85D4QgFQFADRLweBYUkw=",
-  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIEt3pqT5CoxbaVyRgzXlTZt3otRSrpBYTZf0LGOqevTj",
-  "sshfp_ecdsa": "SSHFP 3 1 fac879cfa8b1a1a67ba3bf7177ca078bd5d2496a\nSSHFP 3 2 0fe1f1c3cb0b0dd7ab701169d0f941088620b140f8d3a417a6cba1f10a9894c1",
-  "sshfp_ed25519": "SSHFP 4 1 840cf97be1785fdc70eebcc322ff65318c4489d7\nSSHFP 4 2 d8581523b8ea27ed5e5ff95e750c49aeeaf5a32875f9e1dbf743ae48b2981ef3",
-  "sshfp_rsa": "SSHFP 1 1 3a0def545bd2e7c73058897010f459dc54b1d4dc\nSSHFP 1 2 7005d0f157b25d01ac04fd105210d877b6ba5b020a685d63de928c4ee621c55a",
-  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDkf0A/ZGRcI8cF4NLXJ1JjbzlvOcyo+hKy44/+kFdohyG9Es9wqvdFpzSnnoDYo7ADB+0CIVvlsmcNVvfbY5MkUujF7vWGHgVSpqQ2i+6W/kN+zM/FzdXkGdxIdfQ/JrEzn08kf/uHJUYPFuzqZdA4od1wgCIedTUV5wG73VoKtBcJ0fVYriy4c94pvNZWpjRk2GFBuGyNiLFKT6nF3yAPAAxl+GJoF3Dt3EFH0geJYcVrpFaeo0Rr2otU/3HFg7lOCopxsNkoeghC4WKXUJcWaQ187C5+kgaSkc71ulfyh757tpokHFjqO1D1R1cQIAetF3WreMnAakhtDYMj7AJ7Q/BcK/cFx+guNEZGtgLTYOtb8BlR9IZmU9ByVwgEQGmTHbwUWV8dAAK+ORnLDVUpjU0d/w2HyCcp8BG6QaCUWv9E9XhZt2i+JowYsFnd4OhEfU4P6vbHWsE8SywGy8Jpb6bTb0HTcrzdF0yolE2+16EPgEqbBEhHLDjEY/81kzc=",
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJAWvh3bh4hLuxVpahqPQyRDLE466/LlbLGBLu7KupUMa1A31StB0HlQh/lqsknbuDlsDaliWabFQSiKnbjmdHE=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIJErhbn3XHmCnJx202ulP2SysQWW87qaivrj0SR1j3Xb",
+  "sshfp_ecdsa": "SSHFP 3 1 88ba8e0a7fb7b5fdb7043eb822b92b871c4fa8ca\nSSHFP 3 2 2ac0834b7f55799f0973db1e2d32f57a25adafb3cb084f022c3cdeb072411fad",
+  "sshfp_ed25519": "SSHFP 4 1 063f4a80b82a17743a31a420ee3a6d819df964ac\nSSHFP 4 2 73624d596af1003703472dfd9449f281bcde6e9b87338aed409ac7c39f8c93b0",
+  "sshfp_rsa": "SSHFP 1 1 0907f141846b55eb6ce39df61b7db7c0dfbd4ec1\nSSHFP 1 2 9429fbc834957a06456b3e2043068db642ace1e4f460f71c1b06b6f9cb5ab1af",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC/Ncf+3JlYrxiC67TS/6jBguUqSpZJ0kEG+zNVtN93iujw7GJ3o08J8FOJXQxhjp/+2Y6JVbSGEVL+oVQie9khoIPiCxie2mnafLyAB5KpP0zbDnS/0brPXqNqkpl7ZighutWAtfrXiE3aW8HDJvUlWWaBTY7rXFsKICP2FBTzjRApWziB8RSRlUs7goTy0SmKzvYJSf8wxarLEGkiiWvBz/6ealPaa+MfkRVZ0UPIsqCyyxkAmlwuS8W8rlFdO/FDHtqPbNzq63TQPFo3B7P3FhhVBjXeRRxBsybzj8tHnL9P4iWTLr1hzSCI+zbjoXe0wT87rKpG+ou+KV1jh4LzmXvjosxPZna5nhXd7jzj1gSOXfxVjb2k87pbvxJ2hH7LSpwJv/dM0JzDTy45kHMiaHOhRvY+mqAFaHO2Lbry1lXtu5eRnWbStiy2Uie2YYXy+YWOUD6P5ZBG7nrze8zGRGtxtXRzyHfuADoDnjUPsEhtzOHFwwPi0ZxrSBe3eTk=",
   "sssd_version": "2.2.0",
-  "swapfree": "2.06 GiB",
-  "swapfree_mb": 2105.234375,
+  "swapfree": "2.05 GiB",
+  "swapfree_mb": 2104.24609375,
   "swapsize": "2.07 GiB",
   "swapsize_mb": 2115.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
-    "seconds": 583,
+    "seconds": 555,
     "uptime": "0:09 hours"
   },
   "systemd": true,
@@ -1056,8 +1042,8 @@
   "uptime": "0:09 hours",
   "uptime_days": 0,
   "uptime_hours": 0,
-  "uptime_seconds": 583,
-  "uuid": "59b60a33-37de-4cd3-a368-8e5c1668c544",
+  "uptime_seconds": 555,
+  "uuid": "f7a999a9-fc48-4ac8-b7c3-024bd2e83bbf",
   "virtual": "virtualbox",
   "clientcert": "foo.example.com",
   "clientversion": "5.5.17",

--- a/facts/2.5/redhat-7-x86_64.facts
+++ b/facts/2.5/redhat-7-x86_64.facts
@@ -18,7 +18,7 @@
   "boardmanufacturer": "Oracle Corporation",
   "boardproductname": "VirtualBox",
   "boardserialnumber": "0",
-  "boot_dir_uuid": "6e161d46-c5d1-4fa7-8311-0e30e79f7c5e",
+  "boot_dir_uuid": "e826b9ca-08c4-47e7-8b80-d1d2762c4979",
   "chassistype": "Other",
   "cmdline": {
     "BOOT_IMAGE": "/vmlinuz-3.10.0-1062.el7.x86_64",
@@ -40,12 +40,11 @@
     "processor0": {
       "vendor_id": "GenuineIntel",
       "cpu_family": "6",
-      "model": "62",
-      "model_name": "Intel(R) Core(TM) i7-4930K CPU @ 3.40GHz",
-      "stepping": "4",
-      "microcode": "0x19",
-      "cpu_MHz": "3410.070",
-      "cache_size": "12288 KB",
+      "model": "158",
+      "model_name": "Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz",
+      "stepping": "9",
+      "cpu_MHz": "4199.952",
+      "cache_size": "8192 KB",
       "physical_id": "0",
       "siblings": "1",
       "core_id": "0",
@@ -54,7 +53,7 @@
       "initial_apicid": "0",
       "fpu": "yes",
       "fpu_exception": "yes",
-      "cpuid_level": "13",
+      "cpuid_level": "22",
       "wp": "yes",
       "flags": [
         "fpu",
@@ -79,7 +78,6 @@
         "fxsr",
         "sse",
         "sse2",
-        "ht",
         "syscall",
         "nx",
         "rdtscp",
@@ -99,6 +97,7 @@
         "sse4_1",
         "sse4_2",
         "x2apic",
+        "movbe",
         "popcnt",
         "aes",
         "xsave",
@@ -106,14 +105,20 @@
         "rdrand",
         "hypervisor",
         "lahf_lm",
+        "abm",
+        "3dnowprefetch",
         "fsgsbase",
+        "avx2",
+        "invpcid",
+        "rdseed",
+        "clflushopt",
         "md_clear",
         "flush_l1d"
       ],
-      "bogomips": "6820.14",
+      "bogomips": "8399.90",
       "clflush_size": "64",
       "cache_alignment": "64",
-      "address_sizes": "46 bits physical, 48 bits virtual",
+      "address_sizes": "39 bits physical, 48 bits virtual",
       "power_management": "power management"
     }
   },
@@ -149,7 +154,7 @@
     "product": {
       "name": "VirtualBox",
       "serial_number": "0",
-      "uuid": "5799AB93-61C0-4862-B511-2DA18B3F9744"
+      "uuid": "7F9CFCEE-13C3-48C5-AE6B-B4B4657AE3DB"
     }
   },
   "domain": "example.com",
@@ -244,8 +249,8 @@
   "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
-      "revision": "133076",
-      "version": "6.0.12"
+      "revision": "133893",
+      "version": "5.2.34"
     }
   },
   "id": "root",
@@ -264,9 +269,7 @@
   "interfaces": "eth0,eth1,lo",
   "ip6tables_version": "1.4.21",
   "ipaddress": "10.0.2.15",
-  "ipaddress6_eth1": "fe80::a00:27ff:fe18:f198",
   "ipaddress_eth0": "10.0.2.15",
-  "ipaddress_eth1": "10.255.143.185",
   "ipaddress_lo": "127.0.0.1",
   "iptables_version": "1.4.21",
   "ipv6_enabled": false,
@@ -277,9 +280,9 @@
   "kernelrelease": "3.10.0-1062.el7.x86_64",
   "kernelversion": "3.10.0",
   "load_averages": {
-    "15m": 0.15,
-    "1m": 0.17,
-    "5m": 0.31
+    "15m": 0.18,
+    "1m": 0.33,
+    "5m": 0.37
   },
   "login_defs": {
     "mail_dir": "/var/spool/mail",
@@ -300,9 +303,9 @@
     "usergroups_enab": true,
     "encrypt_method": "SHA512"
   },
-  "macaddress": "08:00:27:c8:3a:d4",
-  "macaddress_eth0": "08:00:27:c8:3a:d4",
-  "macaddress_eth1": "08:00:27:18:f1:98",
+  "macaddress": "08:00:27:ae:46:16",
+  "macaddress_eth0": "08:00:27:ae:46:16",
+  "macaddress_eth1": "08:00:27:ee:93:7c",
   "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
@@ -315,24 +318,24 @@
       "used_bytes": 0
     },
     "system": {
-      "available": "659.43 MiB",
-      "available_bytes": 691466240,
-      "capacity": "33.46%",
+      "available": "689.17 MiB",
+      "available_bytes": 722644992,
+      "capacity": "30.46%",
       "total": "991.04 MiB",
       "total_bytes": 1039179776,
-      "used": "331.61 MiB",
-      "used_bytes": 347713536
+      "used": "301.87 MiB",
+      "used_bytes": 316534784
     }
   },
-  "memoryfree": "659.43 MiB",
-  "memoryfree_mb": 659.43359375,
+  "memoryfree": "689.17 MiB",
+  "memoryfree_mb": 689.16796875,
   "memorysize": "991.04 MiB",
   "memorysize_mb": 991.0390625,
   "mountpoints": {
     "/": {
-      "available": "27.48 GiB",
-      "available_bytes": 29506457600,
-      "capacity": "5.17%",
+      "available": "27.55 GiB",
+      "available_bytes": 29583171584,
+      "capacity": "4.92%",
       "device": "/dev/mapper/rhel_rhel7-root",
       "filesystem": "xfs",
       "options": [
@@ -345,12 +348,12 @@
       ],
       "size": "28.98 GiB",
       "size_bytes": 31114924032,
-      "used": "1.50 GiB",
-      "used_bytes": 1608466432
+      "used": "1.43 GiB",
+      "used_bytes": 1531752448
     },
     "/boot": {
       "available": "871.93 MiB",
-      "available_bytes": 914284544,
+      "available_bytes": 914280448,
       "capacity": "14.01%",
       "device": "/dev/sda1",
       "filesystem": "xfs",
@@ -365,7 +368,7 @@
       "size": "1014.00 MiB",
       "size_bytes": 1063256064,
       "used": "142.07 MiB",
-      "used_bytes": 148971520
+      "used_bytes": 148975616
     },
     "/dev": {
       "available": "484.26 MiB",
@@ -457,8 +460,8 @@
       "used_bytes": 0
     },
     "/run": {
-      "available": "482.65 MiB",
-      "available_bytes": 506097664,
+      "available": "482.64 MiB",
+      "available_bytes": 506081280,
       "capacity": "2.60%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -471,8 +474,8 @@
       ],
       "size": "495.52 MiB",
       "size_bytes": 519589888,
-      "used": "12.87 MiB",
-      "used_bytes": 13492224
+      "used": "12.88 MiB",
+      "used_bytes": 13508608
     },
     "/run/user/0": {
       "available": "99.11 MiB",
@@ -518,14 +521,10 @@
   "mtu_eth1": 1500,
   "mtu_lo": 65536,
   "netmask": "255.255.0.0",
-  "netmask6_eth1": "ffff:ffff:ffff:ffff::",
   "netmask_eth0": "255.255.0.0",
-  "netmask_eth1": "255.255.0.0",
   "netmask_lo": "255.0.0.0",
   "network": "10.0.2.0",
-  "network6_eth1": "fe80::",
   "network_eth0": "10.0.2.0",
-  "network_eth1": "10.255.0.0",
   "network_lo": "127.0.0.0",
   "networking": {
     "dhcp": "10.0.2.2",
@@ -543,34 +542,14 @@
         ],
         "dhcp": "10.0.2.2",
         "ip": "10.0.2.15",
-        "mac": "08:00:27:c8:3a:d4",
+        "mac": "08:00:27:ae:46:16",
         "mtu": 1500,
         "netmask": "255.255.0.0",
         "network": "10.0.2.0"
       },
       "eth1": {
-        "bindings": [
-          {
-            "address": "10.255.143.185",
-            "netmask": "255.255.0.0",
-            "network": "10.255.0.0"
-          }
-        ],
-        "bindings6": [
-          {
-            "address": "fe80::a00:27ff:fe18:f198",
-            "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::"
-          }
-        ],
-        "ip": "10.255.143.185",
-        "ip6": "fe80::a00:27ff:fe18:f198",
-        "mac": "08:00:27:18:f1:98",
-        "mtu": 1500,
-        "netmask": "255.255.0.0",
-        "netmask6": "ffff:ffff:ffff:ffff::",
-        "network": "10.255.0.0",
-        "network6": "fe80::"
+        "mac": "08:00:27:ee:93:7c",
+        "mtu": 1500
       },
       "lo": {
         "bindings": [
@@ -587,7 +566,7 @@
       }
     },
     "ip": "10.0.2.15",
-    "mac": "08:00:27:c8:3a:d4",
+    "mac": "08:00:27:ae:46:16",
     "mtu": 1500,
     "netmask": "255.255.0.0",
     "network": "10.0.2.0",
@@ -625,37 +604,37 @@
       "mount": "/",
       "size": "28.99 GiB",
       "size_bytes": 31130124288,
-      "uuid": "5ef1bf12-a7fd-407c-b63e-23d63c9407e1"
+      "uuid": "9870c2cc-d887-43c1-8629-e1bb87dbc3ed"
     },
     "/dev/mapper/rhel_rhel7-swap": {
       "filesystem": "swap",
       "size": "2.00 GiB",
       "size_bytes": 2147483648,
-      "uuid": "f1b9f482-1ff7-4f9c-b25b-b30e1fe821ab"
+      "uuid": "e655edaa-d5a7-4a92-a38e-2c31c47b8804"
     },
     "/dev/sda1": {
       "filesystem": "xfs",
       "mount": "/boot",
       "size": "1.00 GiB",
       "size_bytes": 1073741824,
-      "uuid": "6e161d46-c5d1-4fa7-8311-0e30e79f7c5e"
+      "uuid": "e826b9ca-08c4-47e7-8b80-d1d2762c4979"
     },
     "/dev/sda2": {
       "filesystem": "LVM2_member",
       "size": "31.00 GiB",
       "size_bytes": 33284947968,
-      "uuid": "dn5f39-mXAv-WAIH-srlZ-Pfww-dPDn-gSI5fd"
+      "uuid": "F4R761-4Kdh-78nB-2KVm-4CY9-Iu5f-L2Clh5"
     }
   },
   "path": "PATH:/opt/puppetlabs/bin:/opt/puppetlabs/puppet/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin",
   "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-4930K CPU @ 3.40GHz",
+  "processor0": "Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz",
   "processorcount": 1,
   "processors": {
     "count": 1,
     "isa": "x86_64",
     "models": [
-      "Intel(R) Core(TM) i7-4930K CPU @ 3.40GHz"
+      "Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz"
     ],
     "physicalcount": 1
   },
@@ -902,7 +881,7 @@
   "puppet_vardir": "/opt/puppetlabs/puppet/cache",
   "puppetversion": "5.5.17",
   "reboot_required": false,
-  "root_dir_uuid": "5ef1bf12-a7fd-407c-b63e-23d63c9407e1",
+  "root_dir_uuid": "9870c2cc-d887-43c1-8629-e1bb87dbc3ed",
   "root_home": "/root",
   "rsyslogd": {
     "version": "8.24.0",
@@ -957,11 +936,6 @@
         "uuid": "5fb06bd0-0bb0-7ffb-45f1-d6edd65f3e03",
         "type": "802-3-ethernet",
         "name": "System eth0"
-      },
-      "eth1": {
-        "uuid": "9c92fad9-6ecb-3e6c-eb4d-8a47c6f50c04",
-        "type": "802-3-ethernet",
-        "name": "System eth1"
       }
     }
   },
@@ -984,18 +958,18 @@
   "ssh": {
     "rsa": {
       "fingerprints": {
-        "sha1": "SSHFP 1 1 0d912c6e4e9a68239c3815233c32efe6a6d76fe1",
-        "sha256": "SSHFP 1 2 82936b474321d5da14d8b9af5590ed5d45d72631ea8601a35e7b7b1986248936"
+        "sha1": "SSHFP 1 1 aa3520a99a025ea9b248735f5dc595f5c8f5cb3e",
+        "sha256": "SSHFP 1 2 79bb8f159f47b4893204afd4dd4d5f9d1660daac5f7d234528b31a8d69f8fa83"
       },
-      "key": "AAAAB3NzaC1yc2EAAAADAQABAAACAQDUlV/VD8MgYhaw8luf5Borsv/UTPDrnLhBq+KleavVR6XeV+1M3i9Z9lUihwG3sTCEw1PEeo7AQCQrpXPjUjaO0BiNudCj99XVxYXV1KMug7MExFNDV4WjXEtxvkjzAq8WxXPFiDbNtYcSakVB3XVldqyG56mM5RitC8RkDutJYVh4XDW3lucofHYwtk4ahLr2cx2jJx6t7d/mc96xNRgJ1Y2gkQha6dI2WXWzE7tDpxb0n/vXxphNixwxlMVnkyMOinq4AfDiyYNVC0PgjNnPaXFn0b1fMk5G/2LHR1sZIBHwWqAxVKqXCvUsbWjs0vki9MYpRXL2l/MmAxayUSbZXtZJJZDZcmLE2cJsFNxoTJoolDlHMZW7WDcZYk8L0eDuT6kJBYcODxKw/0YdqFUqKTAH4T6RmYtwMAbIgxAtBMgKSpx8S0W5sYNYbDSnHjaolE7bd9JN+AiT9t/7q8Is5OOfZM7aIIQZXP0PDPQsuYP0btJlFPvMKkdCP2K3AAyBfJgLMC3SFg22DCHVAPRXSc+0O+lTBm4Xx95BK+ULgR4oBPh/i/9n6pomiSOfIQXoDU9uqRVwvm0BFAM1sluUeZkq7zvRLfoi3MHNcaNzfxcbulZHr7lVQT0zWL3ZcpBUJVAq076dxEeAvmYKBQakkb+ORVWvDWTPQ2seTPMAnw==",
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAACAQCnH0eS1NXx6k6FdTWdV2GnKHzmRz75W9crsDybs1THoQ6ALjrHUMBc66Tt6pjLZNyWFymx70Nr5dod8660S9MwuVz7NYRbAfQAczORHMVlrQx3hNB0ZgV/1L4mW4ZiOlJS2LznPIE6BZtyy8dPCB5KpMp/9eSCqJu1SPPZZa00RxUjlMbRj09vdg0MSLEguTFGfyi4/93kSyPsFbO0uxrYBAGcTlHK279vJ8jjIaN8/JGIGWtDjmyKLy38OUU2ajIbGc+Xl84o5Fe1dvaVgqcUsVq+sf6Pd9gXebEngW7Q1JKiKmAN54n9HBpdQytlGzU5HzzZkPEQeA0Qrey2Ee8EQZEbJVVoDGmHH9hzwxr/Lpt4UF+sjKvKkBrHs49oWhYiRF/5BGr9oePMVRCjbZ2S16qyz/DG7mbtvqTNA87vAoLWBBB/CEMBt9JB8OQdnmHerv7XQ3R9qekODeFIO1iNNu6TkkGwj5Rt58XuFWN3xm2pskxJp2+uhdSrm4xLSupTw2FnqqpnOd1g+k3ij/X7+eyhe3hRyx+WloPOcQyCtxbEPSf+nx8FAQ36fYo9ZgOU2GQdLQtoLepbeAiEN4TsQ6EK0b+hYemcpQV1yzDWxPyPTZLzcLZNm0nhAh1to6Hcb4IQzsbnrrTBI249upWR7HOr9FKIeBb76zTBXSqFdQ==",
       "type": "ssh-rsa"
     }
   },
   "ssh_host_keys": [
     "/etc/ssh/ssh_host_rsa_key"
   ],
-  "sshfp_rsa": "SSHFP 1 1 0d912c6e4e9a68239c3815233c32efe6a6d76fe1\nSSHFP 1 2 82936b474321d5da14d8b9af5590ed5d45d72631ea8601a35e7b7b1986248936",
-  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAACAQDUlV/VD8MgYhaw8luf5Borsv/UTPDrnLhBq+KleavVR6XeV+1M3i9Z9lUihwG3sTCEw1PEeo7AQCQrpXPjUjaO0BiNudCj99XVxYXV1KMug7MExFNDV4WjXEtxvkjzAq8WxXPFiDbNtYcSakVB3XVldqyG56mM5RitC8RkDutJYVh4XDW3lucofHYwtk4ahLr2cx2jJx6t7d/mc96xNRgJ1Y2gkQha6dI2WXWzE7tDpxb0n/vXxphNixwxlMVnkyMOinq4AfDiyYNVC0PgjNnPaXFn0b1fMk5G/2LHR1sZIBHwWqAxVKqXCvUsbWjs0vki9MYpRXL2l/MmAxayUSbZXtZJJZDZcmLE2cJsFNxoTJoolDlHMZW7WDcZYk8L0eDuT6kJBYcODxKw/0YdqFUqKTAH4T6RmYtwMAbIgxAtBMgKSpx8S0W5sYNYbDSnHjaolE7bd9JN+AiT9t/7q8Is5OOfZM7aIIQZXP0PDPQsuYP0btJlFPvMKkdCP2K3AAyBfJgLMC3SFg22DCHVAPRXSc+0O+lTBm4Xx95BK+ULgR4oBPh/i/9n6pomiSOfIQXoDU9uqRVwvm0BFAM1sluUeZkq7zvRLfoi3MHNcaNzfxcbulZHr7lVQT0zWL3ZcpBUJVAq076dxEeAvmYKBQakkb+ORVWvDWTPQ2seTPMAnw==",
+  "sshfp_rsa": "SSHFP 1 1 aa3520a99a025ea9b248735f5dc595f5c8f5cb3e\nSSHFP 1 2 79bb8f159f47b4893204afd4dd4d5f9d1660daac5f7d234528b31a8d69f8fa83",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAACAQCnH0eS1NXx6k6FdTWdV2GnKHzmRz75W9crsDybs1THoQ6ALjrHUMBc66Tt6pjLZNyWFymx70Nr5dod8660S9MwuVz7NYRbAfQAczORHMVlrQx3hNB0ZgV/1L4mW4ZiOlJS2LznPIE6BZtyy8dPCB5KpMp/9eSCqJu1SPPZZa00RxUjlMbRj09vdg0MSLEguTFGfyi4/93kSyPsFbO0uxrYBAGcTlHK279vJ8jjIaN8/JGIGWtDjmyKLy38OUU2ajIbGc+Xl84o5Fe1dvaVgqcUsVq+sf6Pd9gXebEngW7Q1JKiKmAN54n9HBpdQytlGzU5HzzZkPEQeA0Qrey2Ee8EQZEbJVVoDGmHH9hzwxr/Lpt4UF+sjKvKkBrHs49oWhYiRF/5BGr9oePMVRCjbZ2S16qyz/DG7mbtvqTNA87vAoLWBBB/CEMBt9JB8OQdnmHerv7XQ3R9qekODeFIO1iNNu6TkkGwj5Rt58XuFWN3xm2pskxJp2+uhdSrm4xLSupTw2FnqqpnOd1g+k3ij/X7+eyhe3hRyx+WloPOcQyCtxbEPSf+nx8FAQ36fYo9ZgOU2GQdLQtoLepbeAiEN4TsQ6EK0b+hYemcpQV1yzDWxPyPTZLzcLZNm0nhAh1to6Hcb4IQzsbnrrTBI249upWR7HOr9FKIeBb76zTBXSqFdQ==",
   "swapfree": "2.00 GiB",
   "swapfree_mb": 2047.99609375,
   "swapsize": "2.00 GiB",
@@ -1003,8 +977,8 @@
   "system_uptime": {
     "days": 0,
     "hours": 0,
-    "seconds": 286,
-    "uptime": "0:04 hours"
+    "seconds": 319,
+    "uptime": "0:05 hours"
   },
   "systemd": true,
   "systemd_internal_services": {
@@ -1021,11 +995,11 @@
   "tmp_mount_fstype_dev_shm": "tmpfs",
   "tmp_mount_path_dev_shm": "tmpfs",
   "uid_min": "1000",
-  "uptime": "0:04 hours",
+  "uptime": "0:05 hours",
   "uptime_days": 0,
   "uptime_hours": 0,
-  "uptime_seconds": 286,
-  "uuid": "5799AB93-61C0-4862-B511-2DA18B3F9744",
+  "uptime_seconds": 319,
+  "uuid": "7F9CFCEE-13C3-48C5-AE6B-B4B4657AE3DB",
   "virtual": "virtualbox",
   "clientcert": "foo.example.com",
   "clientversion": "5.5.17",

--- a/facts/2.5/redhat-8-x86_64.facts
+++ b/facts/2.5/redhat-8-x86_64.facts
@@ -18,10 +18,10 @@
   "boardmanufacturer": "Oracle Corporation",
   "boardproductname": "VirtualBox",
   "boardserialnumber": "0",
-  "boot_dir_uuid": "4dd44b69-0feb-4b10-9b16-758d1b8c37c7",
+  "boot_dir_uuid": "d9bd9a12-1c50-417b-af81-129b009ad5b1",
   "chassistype": "Other",
   "cmdline": {
-    "BOOT_IMAGE": "(hd0,msdos1)/vmlinuz-4.18.0-80.el8.x86_64",
+    "BOOT_IMAGE": "(hd0,msdos1)/vmlinuz-4.18.0-147.el8.x86_64",
     "root": "/dev/mapper/rhel_rhel8-root",
     "ro": "",
     "no_timer_check": "",
@@ -40,12 +40,11 @@
     "processor0": {
       "vendor_id": "GenuineIntel",
       "cpu_family": "6",
-      "model": "62",
-      "model_name": "Intel(R) Core(TM) i7-4930K CPU @ 3.40GHz",
-      "stepping": "4",
-      "microcode": "0x19",
-      "cpu_MHz": "3410.070",
-      "cache_size": "12288 KB",
+      "model": "158",
+      "model_name": "Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz",
+      "stepping": "9",
+      "cpu_MHz": "4199.952",
+      "cache_size": "8192 KB",
       "physical_id": "0",
       "siblings": "1",
       "core_id": "0",
@@ -54,7 +53,7 @@
       "initial_apicid": "0",
       "fpu": "yes",
       "fpu_exception": "yes",
-      "cpuid_level": "13",
+      "cpuid_level": "22",
       "wp": "yes",
       "flags": [
         "fpu",
@@ -79,7 +78,6 @@
         "fxsr",
         "sse",
         "sse2",
-        "ht",
         "syscall",
         "nx",
         "rdtscp",
@@ -100,6 +98,7 @@
         "sse4_1",
         "sse4_2",
         "x2apic",
+        "movbe",
         "popcnt",
         "aes",
         "xsave",
@@ -107,15 +106,23 @@
         "rdrand",
         "hypervisor",
         "lahf_lm",
+        "abm",
+        "3dnowprefetch",
+        "invpcid_single",
         "pti",
         "fsgsbase",
+        "avx2",
+        "invpcid",
+        "rdseed",
+        "clflushopt",
+        "md_clear",
         "flush_l1d"
       ],
-      "bugs": "cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf",
-      "bogomips": "6820.14",
+      "bugs": "cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds swapgs",
+      "bogomips": "8399.90",
       "clflush_size": "64",
       "cache_alignment": "64",
-      "address_sizes": "46 bits physical, 48 bits virtual",
+      "address_sizes": "39 bits physical, 48 bits virtual",
       "power_management": "power management"
     }
   },
@@ -151,7 +158,7 @@
     "product": {
       "name": "VirtualBox",
       "serial_number": "0",
-      "uuid": "0251cd38-5cdf-48aa-8fc6-b8c3e1f9294f"
+      "uuid": "ba8bcba8-dc71-4e6b-a03c-08a9ea2ae15d"
     }
   },
   "domain": "example.com",
@@ -246,8 +253,8 @@
   "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
-      "revision": "133076",
-      "version": "6.0.12"
+      "revision": "133893",
+      "version": "5.2.34"
     }
   },
   "id": "root",
@@ -266,9 +273,8 @@
   "interfaces": "eth0,eth1,lo",
   "ip6tables_version": "1.8.2",
   "ipaddress": "10.0.2.15",
-  "ipaddress6_eth1": "fe80::a00:27ff:fe29:e0a5",
+  "ipaddress6_eth1": "fe80::8bd6:ef2b:a75c:3e87",
   "ipaddress_eth0": "10.0.2.15",
-  "ipaddress_eth1": "10.255.113.78",
   "ipaddress_lo": "127.0.0.1",
   "iptables_version": "1.8.2",
   "ipv6_enabled": false,
@@ -276,12 +282,12 @@
   "is_virtual": true,
   "kernel": "Linux",
   "kernelmajversion": "4.18",
-  "kernelrelease": "4.18.0-80.el8.x86_64",
+  "kernelrelease": "4.18.0-147.el8.x86_64",
   "kernelversion": "4.18.0",
   "load_averages": {
-    "15m": 0.21,
-    "1m": 0.32,
-    "5m": 0.44
+    "15m": 0.27,
+    "1m": 0.76,
+    "5m": 0.59
   },
   "login_defs": {
     "mail_dir": "/var/spool/mail",
@@ -302,39 +308,39 @@
     "usergroups_enab": true,
     "encrypt_method": "SHA512"
   },
-  "macaddress": "08:00:27:ec:6d:66",
-  "macaddress_eth0": "08:00:27:ec:6d:66",
-  "macaddress_eth1": "08:00:27:29:e0:a5",
+  "macaddress": "08:00:27:87:4c:c1",
+  "macaddress_eth0": "08:00:27:87:4c:c1",
+  "macaddress_eth1": "08:00:27:bb:f2:3e",
   "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
-      "available": "2.06 GiB",
-      "available_bytes": 2215362560,
-      "capacity": "0.34%",
+      "available": "2.05 GiB",
+      "available_bytes": 2205401088,
+      "capacity": "0.60%",
       "total": "2.07 GiB",
-      "total_bytes": 2222977024,
-      "used": "7.26 MiB",
-      "used_bytes": 7614464
+      "total_bytes": 2218782720,
+      "used": "12.76 MiB",
+      "used_bytes": 13381632
     },
     "system": {
-      "available": "531.69 MiB",
-      "available_bytes": 557514752,
-      "capacity": "35.27%",
-      "total": "821.41 MiB",
-      "total_bytes": 861310976,
-      "used": "289.72 MiB",
-      "used_bytes": 303796224
+      "available": "546.46 MiB",
+      "available_bytes": 573001728,
+      "capacity": "33.47%",
+      "total": "821.39 MiB",
+      "total_bytes": 861290496,
+      "used": "274.93 MiB",
+      "used_bytes": 288288768
     }
   },
-  "memoryfree": "531.69 MiB",
-  "memoryfree_mb": 531.6875,
-  "memorysize": "821.41 MiB",
-  "memorysize_mb": 821.41015625,
+  "memoryfree": "546.46 MiB",
+  "memoryfree_mb": 546.45703125,
+  "memorysize": "821.39 MiB",
+  "memorysize_mb": 821.390625,
   "mountpoints": {
     "/": {
-      "available": "26.68 GiB",
-      "available_bytes": 28652232704,
-      "capacity": "7.70%",
+      "available": "26.67 GiB",
+      "available_bytes": 28632293376,
+      "capacity": "7.78%",
       "device": "/dev/mapper/rhel_rhel8-root",
       "filesystem": "xfs",
       "options": [
@@ -345,15 +351,15 @@
         "inode64",
         "noquota"
       ],
-      "size": "28.91 GiB",
-      "size_bytes": 31043657728,
-      "used": "2.23 GiB",
-      "used_bytes": 2391425024
+      "size": "28.92 GiB",
+      "size_bytes": 31047847936,
+      "used": "2.25 GiB",
+      "used_bytes": 2415554560
     },
     "/boot": {
-      "available": "853.81 MiB",
-      "available_bytes": 895283200,
-      "capacity": "15.80%",
+      "available": "844.46 MiB",
+      "available_bytes": 885481472,
+      "capacity": "16.72%",
       "device": "/dev/sda1",
       "filesystem": "xfs",
       "options": [
@@ -366,12 +372,12 @@
       ],
       "size": "1014.00 MiB",
       "size_bytes": 1063256064,
-      "used": "160.19 MiB",
-      "used_bytes": 167972864
+      "used": "169.54 MiB",
+      "used_bytes": 177774592
     },
     "/dev": {
-      "available": "396.77 MiB",
-      "available_bytes": 416047104,
+      "available": "394.71 MiB",
+      "available_bytes": 413884416,
       "capacity": "0%",
       "device": "devtmpfs",
       "filesystem": "devtmpfs",
@@ -379,12 +385,12 @@
         "rw",
         "seclabel",
         "nosuid",
-        "size=406296k",
-        "nr_inodes=101574",
+        "size=404184k",
+        "nr_inodes=101046",
         "mode=755"
       ],
-      "size": "396.77 MiB",
-      "size_bytes": 416047104,
+      "size": "394.71 MiB",
+      "size_bytes": 413884416,
       "used": "0 bytes",
       "used_bytes": 0
     },
@@ -444,7 +450,7 @@
     },
     "/dev/shm": {
       "available": "410.70 MiB",
-      "available_bytes": 430653440,
+      "available_bytes": 430645248,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -455,14 +461,14 @@
         "nodev"
       ],
       "size": "410.70 MiB",
-      "size_bytes": 430653440,
+      "size_bytes": 430645248,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/run": {
-      "available": "400.05 MiB",
-      "available_bytes": 419483648,
-      "capacity": "2.59%",
+      "available": "400.02 MiB",
+      "available_bytes": 419454976,
+      "capacity": "2.60%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
       "options": [
@@ -473,13 +479,13 @@
         "mode=755"
       ],
       "size": "410.70 MiB",
-      "size_bytes": 430653440,
-      "used": "10.65 MiB",
-      "used_bytes": 11169792
+      "size_bytes": 430645248,
+      "used": "10.67 MiB",
+      "used_bytes": 11190272
     },
     "/run/user/0": {
       "available": "82.14 MiB",
-      "available_bytes": 86130688,
+      "available_bytes": 86126592,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -489,17 +495,17 @@
         "nosuid",
         "nodev",
         "relatime",
-        "size=84112k",
+        "size=84108k",
         "mode=700"
       ],
       "size": "82.14 MiB",
-      "size_bytes": 86130688,
+      "size_bytes": 86126592,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/sys/fs/cgroup": {
       "available": "410.70 MiB",
-      "available_bytes": 430653440,
+      "available_bytes": 430645248,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -512,7 +518,7 @@
         "mode=755"
       ],
       "size": "410.70 MiB",
-      "size_bytes": 430653440,
+      "size_bytes": 430645248,
       "used": "0 bytes",
       "used_bytes": 0
     }
@@ -523,12 +529,10 @@
   "netmask": "255.255.0.0",
   "netmask6_eth1": "ffff:ffff:ffff:ffff::",
   "netmask_eth0": "255.255.0.0",
-  "netmask_eth1": "255.255.0.0",
   "netmask_lo": "255.0.0.0",
   "network": "10.0.2.0",
   "network6_eth1": "fe80::",
   "network_eth0": "10.0.2.0",
-  "network_eth1": "10.255.0.0",
   "network_lo": "127.0.0.0",
   "networking": {
     "dhcp": "10.0.2.2",
@@ -546,33 +550,23 @@
         ],
         "dhcp": "10.0.2.2",
         "ip": "10.0.2.15",
-        "mac": "08:00:27:ec:6d:66",
+        "mac": "08:00:27:87:4c:c1",
         "mtu": 1500,
         "netmask": "255.255.0.0",
         "network": "10.0.2.0"
       },
       "eth1": {
-        "bindings": [
-          {
-            "address": "10.255.113.78",
-            "netmask": "255.255.0.0",
-            "network": "10.255.0.0"
-          }
-        ],
         "bindings6": [
           {
-            "address": "fe80::a00:27ff:fe29:e0a5",
+            "address": "fe80::8bd6:ef2b:a75c:3e87",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::"
           }
         ],
-        "ip": "10.255.113.78",
-        "ip6": "fe80::a00:27ff:fe29:e0a5",
-        "mac": "08:00:27:29:e0:a5",
+        "ip6": "fe80::8bd6:ef2b:a75c:3e87",
+        "mac": "08:00:27:bb:f2:3e",
         "mtu": 1500,
-        "netmask": "255.255.0.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
-        "network": "10.255.0.0",
         "network6": "fe80::"
       },
       "lo": {
@@ -590,26 +584,26 @@
       }
     },
     "ip": "10.0.2.15",
-    "mac": "08:00:27:ec:6d:66",
+    "mac": "08:00:27:87:4c:c1",
     "mtu": 1500,
     "netmask": "255.255.0.0",
     "network": "10.0.2.0",
     "primary": "eth0"
   },
   "openldap_arch": "i386",
-  "openssh_version": "7.8",
+  "openssh_version": "8.0",
   "operatingsystem": "RedHat",
   "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.0",
+  "operatingsystemrelease": "8.1",
   "os": {
     "architecture": "x86_64",
     "family": "RedHat",
     "hardware": "x86_64",
     "name": "RedHat",
     "release": {
-      "full": "8.0",
+      "full": "8.1",
       "major": "8",
-      "minor": "0"
+      "minor": "1"
     },
     "selinux": {
       "config_mode": "enforcing",
@@ -627,40 +621,40 @@
       "filesystem": "xfs",
       "mount": "/",
       "size": "28.93 GiB",
-      "size_bytes": 31058821120,
-      "uuid": "5e08291c-d64e-4477-b06a-4555dc4591f8"
+      "size_bytes": 31063015424,
+      "uuid": "f0187ffb-3593-44a8-a99d-59d17291144c"
     },
     "/dev/mapper/rhel_rhel8-swap": {
       "filesystem": "swap",
       "size": "2.07 GiB",
-      "size_bytes": 2222981120,
-      "uuid": "1a1b9299-975a-4112-9b4f-4ae1af7c916e"
+      "size_bytes": 2218786816,
+      "uuid": "2201702e-8e60-432f-ae76-e3ecb1c4ddf2"
     },
     "/dev/sda1": {
       "filesystem": "xfs",
       "mount": "/boot",
-      "partuuid": "333cb9dc-01",
+      "partuuid": "67d6cf59-01",
       "size": "1.00 GiB",
       "size_bytes": 1073741824,
-      "uuid": "4dd44b69-0feb-4b10-9b16-758d1b8c37c7"
+      "uuid": "d9bd9a12-1c50-417b-af81-129b009ad5b1"
     },
     "/dev/sda2": {
       "filesystem": "LVM2_member",
-      "partuuid": "333cb9dc-02",
+      "partuuid": "67d6cf59-02",
       "size": "31.00 GiB",
       "size_bytes": 33284947968,
-      "uuid": "4dOwrJ-X4Gm-j9kh-qhkN-MDmQ-sUG2-Fxb9pY"
+      "uuid": "La1k3q-K20f-0QwI-s55M-pYcb-Dnha-saSE2K"
     }
   },
   "path": "PATH:/opt/puppetlabs/bin:/opt/puppetlabs/puppet/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin",
   "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-4930K CPU @ 3.40GHz",
+  "processor0": "Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz",
   "processorcount": 1,
   "processors": {
     "count": 1,
     "isa": "x86_64",
     "models": [
-      "Intel(R) Core(TM) i7-4930K CPU @ 3.40GHz"
+      "Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz"
     ],
     "physicalcount": 1
   },
@@ -907,7 +901,7 @@
   "puppet_vardir": "/opt/puppetlabs/puppet/cache",
   "puppetversion": "5.5.17",
   "reboot_required": false,
-  "root_dir_uuid": "5e08291c-d64e-4477-b06a-4555dc4591f8",
+  "root_dir_uuid": "f0187ffb-3593-44a8-a99d-59d17291144c",
   "root_home": "/root",
   "rsyslogd": {
     "version": "8.37.0",
@@ -959,22 +953,22 @@
     },
     "enabled": true,
     "connection": {
+      "eth1": {
+        "uuid": "415b5ba9-9bc8-3b3d-975c-91eb2a0177a7",
+        "type": "802-3-ethernet",
+        "name": "Wired connection 1"
+      },
       "eth0": {
         "uuid": "5fb06bd0-0bb0-7ffb-45f1-d6edd65f3e03",
         "type": "802-3-ethernet",
         "name": "System eth0"
-      },
-      "eth1": {
-        "uuid": "9c92fad9-6ecb-3e6c-eb4d-8a47c6f50c04",
-        "type": "802-3-ethernet",
-        "name": "System eth1"
       }
     }
   },
   "simplib__sshd_config": {
     "AuthorizedKeysFile": ".ssh/authorized_keys",
-    "version": "7.8p1",
-    "full_version": "OpenSSH_7.8p1, OpenSSL 1.1.1 FIPS  11 Sep 2018\n"
+    "version": "8.0p1",
+    "full_version": "OpenSSH_8.0p1, OpenSSL 1.1.1c FIPS  28 May 2019\n"
   },
   "simplib_sysctl": {
     "crypto.fips_enabled": 0,
@@ -984,53 +978,53 @@
     "kernel.shmmax": "18446744073692774399",
     "kernel.shmmni": "4096",
     "kernel.tainted": 134230016,
-    "kernel.threads-max": 6348,
+    "kernel.threads-max": 6315,
     "vm.swappiness": 30
   },
   "ssh": {
     "ecdsa": {
       "fingerprints": {
-        "sha1": "SSHFP 3 1 8819887edc0264fe14d2691aa6a27e93d6cc6a63",
-        "sha256": "SSHFP 3 2 a10534321844bcc11ad5874a4488c872fd3ee9e8fa8d9a5f7db83662be1010e2"
+        "sha1": "SSHFP 3 1 a87952451b2ac69f9a87d8c1ffc4fc5758b73875",
+        "sha256": "SSHFP 3 2 72c9d95c9774ec3eaae69842ce70510e85807e1ab6368a17c971c6837ca98350"
       },
-      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDJeBClQup2p/+H0/7oqfuUbrf5h4OqChDoVcyKWp2eX7o+ckhsFbrkZJGx+HmH6T+Py0nLNWUE++EmD4IDushM=",
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBIkQkWEaeEUvRifDGskXZjgT8mzKED99w04K5NhW19GtCmLLY8FjeZz2oxUymqHdbnil6KM1vsnx7LV4+H4yx1k=",
       "type": "ecdsa-sha2-nistp256"
     },
     "ed25519": {
       "fingerprints": {
-        "sha1": "SSHFP 4 1 ec97233844eddfd97e2e9c2e9fab9766bc2ff79a",
-        "sha256": "SSHFP 4 2 26d67f086ba1a238c08086f706268c7c8fc33898c08a7a429d18c8b3f2c3efdd"
+        "sha1": "SSHFP 4 1 69f161f0efbe3dbfda587fc5fb3d1492c4f7ecb5",
+        "sha256": "SSHFP 4 2 79192ccca4967500d32f9c382eae3c36c0151e77000f15d10c4abd629df20e7e"
       },
-      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIOHmtRfpEYaMlzrqcsV1N/cj1niZdwi/IA+Z0TtW6AH2",
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAID2gXngKwBVP9e+S7nwu8Fg8JPgZwoeCN9KU1c6CoH+A",
       "type": "ssh-ed25519"
     },
     "rsa": {
       "fingerprints": {
-        "sha1": "SSHFP 1 1 3d57d1ddb8eb3c4469e62ef4e8231642564ed550",
-        "sha256": "SSHFP 1 2 6b6230deb9d5760304f563d1036e2026675ba94c879d906287c0c8daaffdd65f"
+        "sha1": "SSHFP 1 1 1617b2f4728dad11401b72ab0eb2f758694ce589",
+        "sha256": "SSHFP 1 2 41b3812347a0af289bd636ca66a37b8ce09ea59cc44333b22af01943a17e1d33"
       },
-      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABAQDIuV3pa4Jq2VHUH7XXy8ImPDyJCqIm9Ri2HfwsSTnw/u68+RMoMdOumlc8JZRAGG/OUiYg8QBXloW4mAl7MZvQJac5q6LnRA7ebcb8oGSArxa0bRJZHr23UzS90/BQND2DzC1a1BXMukVFxZIsli7Ghjp10FJX9EiDAxwBFzMGVH915Y9PkDm3gu5XTWNbhvMz1wvJvnBl8RgOT5puW65b6CuAoSoaUpm2adFMAdZ6Nd/qRAy9uIHZ77CLBIFUJiauDJg14Bg/LRSiTvJ2F4NAY+oBWYDXunVGcUl07Rllafik3QZT56V1bUyRl/s8dKmsjBlKbisenQDT8GnpTMWX",
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDkTVUCMLx0TEmp7x5bwR+3MqTRa0jHDWoV1XvoSyfd9vVmrTu+NSxsW5CfTF7Hf33CXVPjS3sUh2FLf0MhIq1qnvzrjZ8vX1eOpfjc+ZgL5rU0+d3mpChkHKoTudyGkhhhOK1mqRIeGIWh+r1tRryixOaTvJ3VAeaf0NlqKrI0PhQ64rLivh1euk21HPc+j1BZgUnOenFhQRhn/Ni9rji9JXpqgNnSqlzW1AgBYTUwWtmWMf+pNzNVEylstelx8/4VeUPEmgi7QCsQZiJkLQ4CQhICMfefrtDogg9DxcYHZN2m9hrwMfB3TvKVVRIiGAEvRDikXVNIPf3RsKl6S7t7mSq4Kizt1rS+kOqZgWn073umUX63MkAmvGHOa0MCf15IfDykvv3lZYbycmKqd/k1MTejq4GwnA6IgRpK70uCkSx1Vq7NGZkMpb5sSKJDItusD7lV1w3oLJ1SG9nY9gj9K2DPbzAO72zg73uN43S1uppuxa2Ja07ony6f0spxNk0=",
       "type": "ssh-rsa"
     }
   },
   "ssh_host_keys": [
     "/etc/ssh/ssh_host_rsa_key"
   ],
-  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDJeBClQup2p/+H0/7oqfuUbrf5h4OqChDoVcyKWp2eX7o+ckhsFbrkZJGx+HmH6T+Py0nLNWUE++EmD4IDushM=",
-  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIOHmtRfpEYaMlzrqcsV1N/cj1niZdwi/IA+Z0TtW6AH2",
-  "sshfp_ecdsa": "SSHFP 3 1 8819887edc0264fe14d2691aa6a27e93d6cc6a63\nSSHFP 3 2 a10534321844bcc11ad5874a4488c872fd3ee9e8fa8d9a5f7db83662be1010e2",
-  "sshfp_ed25519": "SSHFP 4 1 ec97233844eddfd97e2e9c2e9fab9766bc2ff79a\nSSHFP 4 2 26d67f086ba1a238c08086f706268c7c8fc33898c08a7a429d18c8b3f2c3efdd",
-  "sshfp_rsa": "SSHFP 1 1 3d57d1ddb8eb3c4469e62ef4e8231642564ed550\nSSHFP 1 2 6b6230deb9d5760304f563d1036e2026675ba94c879d906287c0c8daaffdd65f",
-  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQDIuV3pa4Jq2VHUH7XXy8ImPDyJCqIm9Ri2HfwsSTnw/u68+RMoMdOumlc8JZRAGG/OUiYg8QBXloW4mAl7MZvQJac5q6LnRA7ebcb8oGSArxa0bRJZHr23UzS90/BQND2DzC1a1BXMukVFxZIsli7Ghjp10FJX9EiDAxwBFzMGVH915Y9PkDm3gu5XTWNbhvMz1wvJvnBl8RgOT5puW65b6CuAoSoaUpm2adFMAdZ6Nd/qRAy9uIHZ77CLBIFUJiauDJg14Bg/LRSiTvJ2F4NAY+oBWYDXunVGcUl07Rllafik3QZT56V1bUyRl/s8dKmsjBlKbisenQDT8GnpTMWX",
-  "sssd_version": "2.0.0",
-  "swapfree": "2.06 GiB",
-  "swapfree_mb": 2112.734375,
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBIkQkWEaeEUvRifDGskXZjgT8mzKED99w04K5NhW19GtCmLLY8FjeZz2oxUymqHdbnil6KM1vsnx7LV4+H4yx1k=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAID2gXngKwBVP9e+S7nwu8Fg8JPgZwoeCN9KU1c6CoH+A",
+  "sshfp_ecdsa": "SSHFP 3 1 a87952451b2ac69f9a87d8c1ffc4fc5758b73875\nSSHFP 3 2 72c9d95c9774ec3eaae69842ce70510e85807e1ab6368a17c971c6837ca98350",
+  "sshfp_ed25519": "SSHFP 4 1 69f161f0efbe3dbfda587fc5fb3d1492c4f7ecb5\nSSHFP 4 2 79192ccca4967500d32f9c382eae3c36c0151e77000f15d10c4abd629df20e7e",
+  "sshfp_rsa": "SSHFP 1 1 1617b2f4728dad11401b72ab0eb2f758694ce589\nSSHFP 1 2 41b3812347a0af289bd636ca66a37b8ce09ea59cc44333b22af01943a17e1d33",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDkTVUCMLx0TEmp7x5bwR+3MqTRa0jHDWoV1XvoSyfd9vVmrTu+NSxsW5CfTF7Hf33CXVPjS3sUh2FLf0MhIq1qnvzrjZ8vX1eOpfjc+ZgL5rU0+d3mpChkHKoTudyGkhhhOK1mqRIeGIWh+r1tRryixOaTvJ3VAeaf0NlqKrI0PhQ64rLivh1euk21HPc+j1BZgUnOenFhQRhn/Ni9rji9JXpqgNnSqlzW1AgBYTUwWtmWMf+pNzNVEylstelx8/4VeUPEmgi7QCsQZiJkLQ4CQhICMfefrtDogg9DxcYHZN2m9hrwMfB3TvKVVRIiGAEvRDikXVNIPf3RsKl6S7t7mSq4Kizt1rS+kOqZgWn073umUX63MkAmvGHOa0MCf15IfDykvv3lZYbycmKqd/k1MTejq4GwnA6IgRpK70uCkSx1Vq7NGZkMpb5sSKJDItusD7lV1w3oLJ1SG9nY9gj9K2DPbzAO72zg73uN43S1uppuxa2Ja07ony6f0spxNk0=",
+  "sssd_version": "2.2.0",
+  "swapfree": "2.05 GiB",
+  "swapfree_mb": 2103.234375,
   "swapsize": "2.07 GiB",
-  "swapsize_mb": 2119.99609375,
+  "swapsize_mb": 2115.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
-    "seconds": 256,
+    "seconds": 268,
     "uptime": "0:04 hours"
   },
   "systemd": true,
@@ -1046,8 +1040,8 @@
   "uptime": "0:04 hours",
   "uptime_days": 0,
   "uptime_hours": 0,
-  "uptime_seconds": 256,
-  "uuid": "0251cd38-5cdf-48aa-8fc6-b8c3e1f9294f",
+  "uptime_seconds": 268,
+  "uuid": "ba8bcba8-dc71-4e6b-a03c-08a9ea2ae15d",
   "virtual": "virtualbox",
   "clientcert": "foo.example.com",
   "clientversion": "5.5.17",

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -23,6 +23,13 @@ describe 'look out muppets' do
       end
 
       it 'should collect valid fact data' do
+        # Delete NAT interface so facter does not report randomly generated ip addresses
+        if fact_on(host, 'ipaddress_eth1') != '' and fact_on(host, 'operatingsystemmajrelease') != '6'
+          on host, 'nmcli connection delete id System\ eth1'
+        end
+        if fact_on(host, 'ipaddress_enp0s8') != '' and fact_on(host, 'operatingsystemmajrelease') != '6'
+          on host, 'nmcli connection delete id System\ enp0s8'
+        end
         # Stupid RSpec tricks
         output = on(host, 'puppet facts --render-as json').stdout
 


### PR DESCRIPTION
Update acceptance test to disable NAT interface
Update collected facts for RHEL 8, RHEL 7, CentOS 8, and OEL8

SIMP-7502 #close