### PR TITLE
(SIMP-7966) Clean up OEL network information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2020-07-27 / 3.1.2 - Clean up OEL facts
+- OEL facts contained `eth1` references with additional user IPs that
+  should not be present; removed these facts
+
 ## 2020-02-25 / 3.1.1 - Update OEL facts
 - The OEL fact sets were old to the point of breaking newer code
 

--- a/facts/2.5/oraclelinux-6-x86_64.facts
+++ b/facts/2.5/oraclelinux-6-x86_64.facts
@@ -253,14 +253,13 @@
     "upstart",
     "sysv"
   ],
-  "interfaces": "eth0,eth1,lo",
+  "interfaces": "eth0,lo",
   "ip6tables_version": "1.4.7",
   "ipaddress": "10.0.2.15",
   "ipaddress6": "fe80::a00:27ff:fee3:3cfc",
   "ipaddress6_eth0": "fe80::a00:27ff:fee3:3cfc",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
-  "ipaddress_eth1": "10.255.119.191",
   "ipaddress_lo": "127.0.0.1",
   "iptables_version": "1.4.7",
   "ipv6_enabled": true,
@@ -300,7 +299,6 @@
   "lsbrelease": ":base-4.0-amd64:base-4.0-noarch:core-4.0-amd64:core-4.0-noarch",
   "macaddress": "08:00:27:e3:3c:fc",
   "macaddress_eth0": "08:00:27:e3:3c:fc",
-  "macaddress_eth1": "08:00:27:8f:e5:b9",
   "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
@@ -418,21 +416,18 @@
     }
   },
   "mtu_eth0": 1500,
-  "mtu_eth1": 1500,
   "mtu_lo": 65536,
   "netmask": "255.255.0.0",
   "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.0.0",
-  "netmask_eth1": "255.255.0.0",
   "netmask_lo": "255.0.0.0",
   "network": "10.0.2.0",
   "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
-  "network_eth1": "10.255.0.0",
   "network_lo": "127.0.0.0",
   "networking": {
     "dhcp": "10.0.2.2",
@@ -465,20 +460,6 @@
         "network": "10.0.2.0",
         "network6": "fe80::",
         "scope6": "link"
-      },
-      "eth1": {
-        "bindings": [
-          {
-            "address": "10.255.119.191",
-            "netmask": "255.255.0.0",
-            "network": "10.255.0.0"
-          }
-        ],
-        "ip": "10.255.119.191",
-        "mac": "08:00:27:8f:e5:b9",
-        "mtu": 1500,
-        "netmask": "255.255.0.0",
-        "network": "10.255.0.0"
       },
       "lo": {
         "bindings": [

--- a/facts/2.5/oraclelinux-7-x86_64.facts
+++ b/facts/2.5/oraclelinux-7-x86_64.facts
@@ -252,11 +252,10 @@
     "systemd",
     "sysv"
   ],
-  "interfaces": "eth0,eth1,lo",
+  "interfaces": "eth0,lo",
   "ip6tables_version": "1.4.21",
   "ipaddress": "10.0.2.15",
   "ipaddress_eth0": "10.0.2.15",
-  "ipaddress_eth1": "10.255.198.67",
   "ipaddress_lo": "127.0.0.1",
   "iptables_version": "1.4.21",
   "ipv6_enabled": false,
@@ -292,7 +291,6 @@
   },
   "macaddress": "08:00:27:98:18:f0",
   "macaddress_eth0": "08:00:27:98:18:f0",
-  "macaddress_eth1": "08:00:27:12:79:36",
   "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
@@ -506,15 +504,12 @@
     }
   },
   "mtu_eth0": 1500,
-  "mtu_eth1": 1500,
   "mtu_lo": 65536,
   "netmask": "255.255.0.0",
   "netmask_eth0": "255.255.0.0",
-  "netmask_eth1": "255.255.0.0",
   "netmask_lo": "255.0.0.0",
   "network": "10.0.2.0",
   "network_eth0": "10.0.2.0",
-  "network_eth1": "10.255.0.0",
   "network_lo": "127.0.0.0",
   "networking": {
     "dhcp": "10.0.2.2",
@@ -536,20 +531,6 @@
         "mtu": 1500,
         "netmask": "255.255.0.0",
         "network": "10.0.2.0"
-      },
-      "eth1": {
-        "bindings": [
-          {
-            "address": "10.255.198.67",
-            "netmask": "255.255.0.0",
-            "network": "10.255.0.0"
-          }
-        ],
-        "ip": "10.255.198.67",
-        "mac": "08:00:27:12:79:36",
-        "mtu": 1500,
-        "netmask": "255.255.0.0",
-        "network": "10.255.0.0"
       },
       "lo": {
         "bindings": [
@@ -938,11 +919,6 @@
         "uuid": "5fb06bd0-0bb0-7ffb-45f1-d6edd65f3e03",
         "type": "802-3-ethernet",
         "name": "System eth0"
-      },
-      "eth1": {
-        "uuid": "9c92fad9-6ecb-3e6c-eb4d-8a47c6f50c04",
-        "type": "802-3-ethernet",
-        "name": "System eth1"
       }
     }
   },

--- a/lib/simp/version.rb
+++ b/lib/simp/version.rb
@@ -1,4 +1,4 @@
 module Simp; end
 module Simp::RspecPuppetFacts
-  VERSION = '3.1.1'
+  VERSION = '3.1.2'
 end


### PR DESCRIPTION
The OEL facts contained additional host networks when they were last
generated with an additional internal IP address. This additional
network was breaking spec tests for other modules within the SIMP
organization. This change removes those settings. Tested against
issues with `pupmod-simp-tcpwrappers`

SIMP-7966 #close