### PR TITLE
(SIMP-7925) Fix simp_grub tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2020-08-04 / 3.1.2 - Update OEL facts
+- Added uniqueid facts to linux systems.  It is used in simp_grub tests.
+
 ## 2020-02-25 / 3.1.1 - Update OEL facts
 - The OEL fact sets were old to the point of breaking newer code
 

--- a/facts/2.5/centos-8-x86_64.facts
+++ b/facts/2.5/centos-8-x86_64.facts
@@ -1016,6 +1016,7 @@
   "tmp_mount_fstype_dev_shm": "tmpfs",
   "tmp_mount_path_dev_shm": "tmpfs",
   "uid_min": "1000",
+  "uniqueid": "007f0100",
   "uptime": "0:03 hours",
   "uptime_days": 0,
   "uptime_hours": 0,

--- a/facts/2.5/oraclelinux-6-x86_64.facts
+++ b/facts/2.5/oraclelinux-6-x86_64.facts
@@ -932,6 +932,7 @@
   "tmp_mount_dev_shm": "rw,seclabel,relatime",
   "tmp_mount_fstype_dev_shm": "tmpfs",
   "tmp_mount_path_dev_shm": "tmpfs",
+  "uniqueid": "007f0100",
   "uid_min": "500",
   "uptime": "0:07 hours",
   "uptime_days": 0,

--- a/facts/2.5/oraclelinux-7-x86_64.facts
+++ b/facts/2.5/oraclelinux-7-x86_64.facts
@@ -1024,6 +1024,7 @@
   "tmp_mount_fstype_dev_shm": "tmpfs",
   "tmp_mount_path_dev_shm": "tmpfs",
   "uid_min": "1000",
+  "uniqueid": "007f0100",
   "uptime": "0:07 hours",
   "uptime_days": 0,
   "uptime_hours": 0,

--- a/facts/2.5/oraclelinux-8-x86_64.facts
+++ b/facts/2.5/oraclelinux-8-x86_64.facts
@@ -1039,6 +1039,7 @@
   "tmp_mount_fstype_dev_shm": "tmpfs",
   "tmp_mount_path_dev_shm": "tmpfs",
   "uid_min": "1000",
+  "uniqueid": "007f0100",
   "uptime": "0:09 hours",
   "uptime_days": 0,
   "uptime_hours": 0,

--- a/facts/2.5/redhat-6-x86_64.facts
+++ b/facts/2.5/redhat-6-x86_64.facts
@@ -658,6 +658,7 @@
   },
   "gid": "root",
   "facterversion": "2.5.0",
+  "uniqueid": "007f0100",
   "boardmanufacturer": "Google",
   "swapsize": "0.00 MB",
   "fqdn": "foo.example.com",

--- a/facts/2.5/redhat-7-x86_64.facts
+++ b/facts/2.5/redhat-7-x86_64.facts
@@ -995,6 +995,7 @@
   "tmp_mount_fstype_dev_shm": "tmpfs",
   "tmp_mount_path_dev_shm": "tmpfs",
   "uid_min": "1000",
+  "uniqueid": "007f0100",
   "uptime": "0:05 hours",
   "uptime_days": 0,
   "uptime_hours": 0,

--- a/facts/2.5/redhat-8-x86_64.facts
+++ b/facts/2.5/redhat-8-x86_64.facts
@@ -1037,6 +1037,7 @@
   "tmp_mount_fstype_dev_shm": "tmpfs",
   "tmp_mount_path_dev_shm": "tmpfs",
   "uid_min": "1000",
+  "uniqueid": "007f0100",
   "uptime": "0:04 hours",
   "uptime_days": 0,
   "uptime_hours": 0,

--- a/lib/simp/version.rb
+++ b/lib/simp/version.rb
@@ -1,4 +1,4 @@
 module Simp; end
 module Simp::RspecPuppetFacts
-  VERSION = '3.1.1'
+  VERSION = '3.1.2'
 end


### PR DESCRIPTION
-  THe simp_grub tests use a fact uniqueid to help generate a hash but
   it is not in all the system facts.

SIMP-7925 #close