### PR TITLE
(SIMP-10450) GHA: Update ubuntu-16.04 to latest

### DIFF
--- a/.github/workflows/pr_glci.yml
+++ b/.github/workflows/pr_glci.yml
@@ -63,7 +63,7 @@ jobs:
   # we restrict ourselves to sending data elsewhere.
   glci-syntax:
     name: '.gitlab-ci.yml Syntax'
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     outputs:
       valid: ${{ steps.validate-glci-file.outputs.valid }}
     steps:
@@ -174,7 +174,7 @@ jobs:
 ###  examine_contexts:
 ###    name: 'Examine Context contents'
 ###    if: always()
-###    runs-on: ubuntu-16.04
+###    runs-on: ubuntu-latest
 ###    needs: [ glci-syntax, contributor-permissions ]
 ###    steps:
 ###      - name: Dump contexts

--- a/.github/workflows/pr_glci_cleanup.yml
+++ b/.github/workflows/pr_glci_cleanup.yml
@@ -93,7 +93,7 @@ jobs:
 ###  examine_contexts:
 ###    name: 'Examine Context contents'
 ###    if: always()
-###    runs-on: ubuntu-16.04
+###    runs-on: ubuntu-latest
 ###    steps:
 ###      - name: Dump contexts
 ###        env:

--- a/.github/workflows/tag_deploy_rubygem.yml
+++ b/.github/workflows/tag_deploy_rubygem.yml
@@ -1,4 +1,6 @@
-# Build & Deploy RubyGem & GitHub release when a SemVer tag is pushed
+# When SemVer tag is pushed: create GitHub release & publish gem to rubygems.org
+#
+# This workflow's jobs are only triggered in repos under the `simp` organization
 # ------------------------------------------------------------------------------
 #
 #             NOTICE: **This file is maintained with puppetsync**
@@ -21,6 +23,19 @@
 #
 # * The CHANGLOG text is altered to remove RPM-style date headers, which don't
 #   render well as markdown on the GitHub release pages
+#
+# * By default, the gem is built and released using the standard rake tasks
+#   from "bundler/gem_tasks".  To override these, create a JSON file at
+#   `.github/workflows.local.json`, using the following format:
+#
+#         {
+#           "gem_build_command": "bundle exec rake build",
+#           "gem_release_command": "bundle exec rake build release:rubygem_push",
+#           "gem_pkg_dir": "pkg"
+#         }
+#
+#   All keys are optional.
+#
 ---
 name: 'Tag: Release to GitHub & rubygems.org'
 
@@ -36,10 +51,12 @@ env:
 jobs:
   releng-checks:
     name: "RELENG checks"
+    if: github.repository_owner == 'simp'
     runs-on: ubuntu-18.04
     outputs:
       build_command: ${{ steps.commands.outputs.build_command }}
       release_command: ${{ steps.commands.outputs.release_command }}
+      pkg_dir: ${{ steps.commands.outputs.pkg_dir }}
     steps:
       - name: "Assert '${{ github.ref }}' is a tag"
         run: '[[ "$GITHUB_REF" =~ ^refs/tags/ ]] || { echo "::error ::GITHUB_REF is not a tag: ${GITHUB_REF}"; exit 1 ; }'
@@ -53,27 +70,45 @@ jobs:
           # By default, these are the standard tasks from "bundler/gem_tasks"
           # To override them in the LOCAL_WORKFLOW_CONFIG_FILE
           GEM_BUILD_COMMAND='bundle exec rake build'
-          GEM_RELEASE_COMMAND='gem push pkg/*.gem'
+          GEM_RELEASE_COMMAND='bundle exec rake build release:rubygem_push'
+          GEM_PKG_DIR='pkg'
+          if jq -r '. | keys' "$LOCAL_WORKFLOW_CONFIG_FILE" 2>/dev/null | \
+              grep -w '"gem_pkg_dir"' &> /dev/null; then
+            GEM_PKG_DIR="$(jq -r .gem_pkg_dir "$LOCAL_WORKFLOW_CONFIG_FILE" )"
+          fi
           if jq -r '. | keys' "$LOCAL_WORKFLOW_CONFIG_FILE" 2>/dev/null | \
               grep -w '"gem_build_command"' &> /dev/null; then
-            GEM_BUILD_COMMAND="$(jq .gem_build_command "$LOCAL_WORKFLOW_CONFIG_FILE" )"
+            GEM_BUILD_COMMAND="$(jq -r .gem_build_command "$LOCAL_WORKFLOW_CONFIG_FILE" )"
           fi
           if jq -r '. | keys' "$LOCAL_WORKFLOW_CONFIG_FILE" 2>/dev/null | \
               grep -w '"gem_release_command"' &> /dev/null; then
-            GEM_RELEASE_COMMAND="$(jq .gem_release_command "$LOCAL_WORKFLOW_CONFIG_FILE" )"
+            GEM_RELEASE_COMMAND="$(jq -r .gem_release_command "$LOCAL_WORKFLOW_CONFIG_FILE" )"
           fi
           echo "::set-output name=build_command::${GEM_BUILD_COMMAND}"
+          echo "::set-output name=pkg_dir::${GEM_PKG_DIR}"
           echo "::set-output name=release_command::${GEM_RELEASE_COMMAND}"
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.5
           bundler-cache: true
       - name: Test build the package
-        run: "${{ steps.commands.outputs.build_command }}"
+        env:
+          GEM_BUILD_COMMAND: ${{ steps.commands.outputs.build_command }}
+        run: "$GEM_BUILD_COMMAND"
+      - name: "Assert '${{ github.ref }}' matches the package version"
+        run: |
+          tag="${GITHUB_REF/refs\/tags\//}"
+          [ -d  "${{ steps.commands.outputs.pkg_dir }}" ] || \
+             { echo "::error ::No directory found at ${{ steps.commands.outputs.pkg_dir }}/" ; exit 3 ; }
+          ls -1 "${{ steps.commands.outputs.pkg_dir }}"/*.gem || \
+             {  echo "::error ::No gem file found at ${{ steps.commands.outputs.pkg_dir }}/*.gem" ; exit 2 ; }
+          [ -f "${{ steps.commands.outputs.pkg_dir }}"/*-${tag}.gem ] || \
+             { echo "::error ::tag '${tag}' does not match package $(ls -1 ${{ steps.commands.outputs.pkg_dir }}/*.gem)"; exit 1 ; }
 
   create-github-release:
     name: Deploy GitHub Release
     needs: [ releng-checks ]
+    if: github.repository_owner == 'simp'
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout code
@@ -117,11 +152,13 @@ jobs:
   deploy-rubygem:
     name: Deploy RubyGem Release
     needs: [ releng-checks ]
+    if: github.repository_owner == 'simp'
     runs-on: ubuntu-18.04
     env:
       RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
       BUILD_COMMAND: ${{ needs.releng-checks.outputs.build_command }}
       RELEASE_COMMAND: ${{ needs.releng-checks.outputs.release_command }}
+      PKG_DIR: ${{ needs.releng-checks.outputs.pkg_dir }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -133,7 +170,12 @@ jobs:
           ruby-version: 2.5
           bundler-cache: true
       - name: Build RubyGem
-        run: '$BUILD_COMMAND'
+        run: |
+          echo "Setting up file permissions..."
+          chmod -R go=u-w .
+
+          echo "Running '$BUILD_COMMAND'..."
+          $BUILD_COMMAND
 
       - name: Release RubyGem
         run: |
@@ -145,8 +187,6 @@ jobs:
           :rubygems_api_key: ${RUBYGEMS_API_KEY}
           EOF
           chmod 0600 ~/.gem/credentials
-
-          chmod -R go=u-w .
 
           echo "Running '$RELEASE_COMMAND'..."
           $RELEASE_COMMAND


### PR DESCRIPTION
GitHub actions' Ubuntu 16.04 environment will be removed on Sept 20,
2021.  This patch migrates all workflow using the `ubuntu-16.04`
environment to `ubuntu-latest`.

The patch enforces a standardized asset baseline using simp/puppetsync,
and may apply other updates to ensure conformity.
[SIMP-10544] #close
[SIMP-10450] #comment Add `release_rpms` to rubygem-simp-rspec-puppet-facts