### PR TITLE
Pin puppetlabs_spec_helper gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2022-02-27 / 3.3.1 - Pin puppetlabs_spec_helper to ~> 3.0
+
 ## 2021-06-16 / 3.3.0 - Add partial matching to SIMP_FACTS_OS
 - `SIMP_FACTS_OS` can now match factsets' full name, partial name, or regexp
 

--- a/Gemfile
+++ b/Gemfile
@@ -21,4 +21,5 @@ group :test do
   gem 'beaker-rspec'
   gem 'beaker-windows'
   gem 'simp-beaker-helpers', ['>= 1.18.2', '< 2.0']
+  gem 'puppetlabs_spec_helper', '~> 3.0'
 end

--- a/lib/simp/version.rb
+++ b/lib/simp/version.rb
@@ -1,4 +1,4 @@
 module Simp; end
 module Simp::RspecPuppetFacts
-  VERSION = '3.3.0'
+  VERSION = '3.3.1'
 end


### PR DESCRIPTION
This patch pins puppetlabs_spec_helper to `~> 3.0` to prevent test setup from failing.

Related to https://github.com/simp/rubygem-simp-beaker-helpers/issues/165