### PR TITLE
Allow versionless metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2022-06-20 / 3.4.0 - Allow versionless metadata
+- Allow lists of supported OSs that are not pinned to specific versions
+- Install puppet from gem if the facter version is explicitly set
+  - Prep for facter 4.X support
+  - Skip hosts where the gem install fails
+
 ## 2022-02-27 / 3.3.1 - Pin puppetlabs_spec_helper to ~> 3.0
 
 ## 2021-06-16 / 3.3.0 - Add partial matching to SIMP_FACTS_OS

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 # SIMP_GEM_SERVERS   | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION     | specifies the version of the puppet gem to load
 # FACTER_GEM_VERSION | specifies the version of the facter to load
-puppetversion = ENV.fetch('PUPPET_VERSION', '~> 5.5')
+puppetversion = ENV.fetch('PUPPET_VERSION', '~> 7.0')
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
@@ -20,6 +20,6 @@ group :test do
   gem 'beaker'
   gem 'beaker-rspec'
   gem 'beaker-windows'
-  gem 'simp-beaker-helpers', ['>= 1.18.2', '< 2.0']
-  gem 'puppetlabs_spec_helper', '~> 3.0'
+  gem 'simp-beaker-helpers', ['>= 1.25.0', '< 2.0']
+  gem 'puppetlabs_spec_helper', '~> 4.0'
 end

--- a/lib/simp/version.rb
+++ b/lib/simp/version.rb
@@ -1,4 +1,4 @@
 module Simp; end
 module Simp::RspecPuppetFacts
-  VERSION = '3.3.1'
+  VERSION = '3.4.0'
 end

--- a/simp-rspec-puppet-facts.gemspec
+++ b/simp-rspec-puppet-facts.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec'                  , '~> 3.2'
 
   s.add_runtime_dependency     'json'                   , '>= 1.0'
-  s.add_runtime_dependency     'facter'                 , '>= 2.5.0' , '< 3.0'
+  s.add_runtime_dependency     'facter'                 , '>= 2.5.0', '< 5.0'
 
   s.add_development_dependency 'pry'                    , '>= 0'
   s.add_development_dependency 'tins'                   , '>= 1.6'

--- a/spec/acceptance/nodesets/almalinux8.yml
+++ b/spec/acceptance/nodesets/almalinux8.yml
@@ -6,15 +6,13 @@
   end
 -%>
 HOSTS:
-  el8:
+  el8.beaker.test:
     roles:
       - linux
       - default
     platform:   el-8-x86_64
-    box:        rockylinux/8
+    box:        almalinux/8
     hypervisor: <%= hypervisor %>
-    # NFS installation is broken
-    synced_folder: disabled
 
 CONFIG:
   validate: false

--- a/spec/acceptance/nodesets/almalinux9.yml
+++ b/spec/acceptance/nodesets/almalinux9.yml
@@ -6,15 +6,13 @@
   end
 -%>
 HOSTS:
-  el8:
+  el9.beaker.test:
     roles:
       - linux
       - default
-    platform:   el-8-x86_64
-    box:        rockylinux/8
+    platform:   el-9-x86_64
+    box:        almalinux/9
     hypervisor: <%= hypervisor %>
-    # NFS installation is broken
-    synced_folder: disabled
 
 CONFIG:
   validate: false

--- a/spec/acceptance/nodesets/centos8.yml
+++ b/spec/acceptance/nodesets/centos8.yml
@@ -11,7 +11,7 @@ HOSTS:
       - linux
       - default
     platform:   el-8-x86_64
-    box:        generic/centos8
+    box:        centos/stream8
     hypervisor: <%= hypervisor %>
 
 CONFIG:

--- a/spec/acceptance/nodesets/centos9.yml
+++ b/spec/acceptance/nodesets/centos9.yml
@@ -6,15 +6,13 @@
   end
 -%>
 HOSTS:
-  el8:
+  el9.beaker.test:
     roles:
       - linux
       - default
-    platform:   el-8-x86_64
-    box:        rockylinux/8
+    platform:   el-9-x86_64
+    box:        generic/centos9s
     hypervisor: <%= hypervisor %>
-    # NFS installation is broken
-    synced_folder: disabled
 
 CONFIG:
   validate: false

--- a/spec/acceptance/nodesets/rhel8.yml
+++ b/spec/acceptance/nodesets/rhel8.yml
@@ -8,13 +8,14 @@
 HOSTS:
   rhel8:
     roles:
-      - default
       - linux
+      - default
     platform:   el-8-x86_64
     box:        generic/rhel8
     hypervisor: <%= hypervisor %>
 
 CONFIG:
+  validate: false
   log_level: verbose
   type: aio
 <% if ENV['BEAKER_PUPPET_COLLECTION'] -%>

--- a/spec/acceptance/nodesets/rhel9.yml
+++ b/spec/acceptance/nodesets/rhel9.yml
@@ -6,15 +6,13 @@
   end
 -%>
 HOSTS:
-  el8:
+  rhel9:
     roles:
       - linux
       - default
-    platform:   el-8-x86_64
-    box:        rockylinux/8
+    platform:   el-9-x86_64
+    box:        generic/rhel9
     hypervisor: <%= hypervisor %>
-    # NFS installation is broken
-    synced_folder: disabled
 
 CONFIG:
   validate: false

--- a/spec/acceptance/nodesets/win_2012r2.yml
+++ b/spec/acceptance/nodesets/win_2012r2.yml
@@ -21,7 +21,6 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: aio
-  vagrant_memsize: 256
 <% if ENV['BEAKER_PUPPET_ENVIRONMENT'] -%>
   puppet_environment: <%= ENV['BEAKER_PUPPET_ENVIRONMENT'] %>
 <% end -%>

--- a/spec/acceptance/nodesets/win_2016.yml
+++ b/spec/acceptance/nodesets/win_2016.yml
@@ -22,7 +22,6 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: aio
-  vagrant_memsize: 256
 <% if ENV['BEAKER_PUPPET_ENVIRONMENT'] -%>
   puppet_environment: <%= ENV['BEAKER_PUPPET_ENVIRONMENT'] %>
 <% end -%>

--- a/spec/acceptance/nodesets/win_2019.yml
+++ b/spec/acceptance/nodesets/win_2019.yml
@@ -21,7 +21,6 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: aio
-  vagrant_memsize: 256
 <% if ENV['BEAKER_PUPPET_ENVIRONMENT'] -%>
   puppet_environment: <%= ENV['BEAKER_PUPPET_ENVIRONMENT'] %>
 <% end -%>

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -37,10 +37,14 @@ describe 'look out muppets' do
       end
 
       it 'should collect valid fact data' do
-        # Stupid RSpec tricks
         output = on(host, 'puppet facts --render-as json').stdout
 
-        expect{@output << JSON.parse(output)['values']}.to_not raise_error
+        expect do
+          parsed_output = JSON.parse(output)
+
+          # Something changed in the puppet facts output so handle both cases
+          @output.push(parsed_output['values'] || parsed_output)
+        end.to_not raise_error
       end
 
       # This should work regardless of OS

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -4,7 +4,6 @@ require 'yaml'
 require 'simp/beaker_helpers'
 include Simp::BeakerHelpers
 
-require 'beaker/puppet_install_helper'
 require 'beaker-windows'
 include BeakerWindows::Path
 include BeakerWindows::Powershell
@@ -12,13 +11,39 @@ include BeakerWindows::Registry
 include BeakerWindows::WindowsFeature
 
 unless ENV['BEAKER_provision'] == 'no'
+  to_skip = []
+
   hosts.each do |host|
     # Install Puppet
     if host.is_pe?
       install_pe
+    elsif ENV['FACTER_GEM_VERSION']
+      begin
+        install_puppet_from_gem_on(
+          host,
+          version: ENV['PUPPET_VERSION'],
+          facter_version: ENV['FACTER_GEM_VERSION']
+        )
+
+        # Make scaffold dirs?
+        code_dir = on(host, 'puppet config print codedir').stdout.strip
+
+        host.mkdir_p("#{code_dir}/modules")
+      rescue => e
+        puts "#{host} does not support installing puppet from Gem...skipping"
+        puts e
+
+        to_skip << host
+
+        next
+      end
     else
       install_puppet
     end
+  end
+
+  to_skip.each do |host|
+    hosts.delete(host)
   end
 end
 


### PR DESCRIPTION
* Allow lists of supported OSs that are not pinned to specific versions
  in the metadata.json
* Install puppet from gem if the facter version is explicitly set
  * Prep for facter 4.X support
  * Skip hosts where the gem install fails
