### PR TITLE
Ignore default datasets from facterdb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2023-04-17 / 3.6.1 - Ignore upstream facterdb factsets
+- Simply ignores non-simp factsets by not merging results
+- This is quick measure to get simp/simp spec tests working with missing
+  factsets from 3.6.0
+- Follow-on issue should remove all logic to to with lookups from default
+  facterdb data sources
+
+
 ## 2023-02-16 / 3.6.0 - Add initial facter 4.3 factsets
 - Added initial facter 4.3 factsets
 

--- a/lib/simp/rspec-puppet-facts.rb
+++ b/lib/simp/rspec-puppet-facts.rb
@@ -76,7 +76,8 @@ module Simp::RspecPuppetFacts
     rfh_h = {}
     rfh_h = Simp::RspecPuppetFacts::Shim.on_supported_os(masked_opts) unless masked_opts[:supported_os]&.empty?
 
-    merged_os_hash = rfh_h.merge(simp_h)
+    #merged_os_hash = rfh_h.merge(simp_h)  # we should NOT merge default facterdb factsets
+    merged_os_hash = simp_h
     h = merged_os_hash.select{|k,v| supported_os_strings(opts, merged_os_hash.keys).include? k}
 
     h.each do | os, facts |

--- a/lib/simp/version.rb
+++ b/lib/simp/version.rb
@@ -1,4 +1,4 @@
 module Simp; end
 module Simp::RspecPuppetFacts
-  VERSION = '3.6.0'
+  VERSION = '3.6.1'
 end


### PR DESCRIPTION
Before this patch, a call to an os missing from the simp factsets would fall through to facterdb's default data.  However, this data is inappropriate for SIMP spec tests―it is missing critical facts and the keys are no deep-symbolized

For the time being, this patch simply ignores non-simp factsets by not merging results from facterdb.  This is quick measure to get simp/simp spec tests working with missing factsets from 3.6.0 (OEL7, RHEL7)

A follow-on patch is expected to remove all logic to to with lookups from default facterdb data sources