### PR TITLE
Add missing augeasprovider_grub_version fact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2023-10-11 / 3.8.2 - Add missing augeasprovider_grub_version fact
+- Add missing `augeasprovider_grub_version` fact to amazon-2, oraclelinux-7,
+  and oraclelinux-8 fact sets
+
 ## 2023-09-27 / 3.8.1 - Fix GHA release workflow
 - Fix GHA release workflow
 

--- a/facts/4.5/amazon-2-x86_64.facts
+++ b/facts/4.5/amazon-2-x86_64.facts
@@ -73,6 +73,7 @@
   "augeas": {
     "version": "1.13.0"
   },
+  "augeasprovider_grub_version": 2,
   "augeasversion": "1.13.0",
   "bios_release_date": "12/01/2006",
   "bios_vendor": "innotek GmbH",

--- a/facts/4.5/oraclelinux-7-x86_64.facts
+++ b/facts/4.5/oraclelinux-7-x86_64.facts
@@ -76,6 +76,7 @@
   "augeas": {
     "version": "1.13.0"
   },
+  "augeasprovider_grub_version": 2,
   "augeasversion": "1.13.0",
   "bios_release_date": "12/01/2006",
   "bios_vendor": "innotek GmbH",

--- a/facts/4.5/oraclelinux-8-x86_64.facts
+++ b/facts/4.5/oraclelinux-8-x86_64.facts
@@ -115,6 +115,7 @@
   "augeas": {
     "version": "1.13.0"
   },
+  "augeasprovider_grub_version": 2,
   "augeasversion": "1.13.0",
   "bios_release_date": "12/01/2006",
   "bios_vendor": "innotek GmbH",

--- a/lib/simp/version.rb
+++ b/lib/simp/version.rb
@@ -1,4 +1,4 @@
 module Simp; end
 module Simp::RspecPuppetFacts
-  VERSION = '3.8.1'
+  VERSION = '3.8.2'
 end


### PR DESCRIPTION
Add missing `augeasprovider_grub_version` fact to amazon-2, oraclelinux-7, and oraclelinux-8 fact sets